### PR TITLE
Product naming: Genie Spaces→Agents, Semantic Layer→Metrics, Glossary→Pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Bundles** + `post_deploy.py`.
 
 > **Product accuracy:** Genie Ontology is the *learned* enterprise context layer
 > (gated / Private Preview) built on top of the customer's *governed* UC Business
-> Semantics (metric views, glossary, domains — largely GA). The foundation
+> Semantics (metric views, Pages, domains — largely GA). The foundation
 > **feeds** the ontology. The app never positions the learned layer as GA.
 
 ## Prerequisites
@@ -104,14 +104,14 @@ catalog-level SELECT is needed). Pillars whose data the SP can't read degrade
 gracefully to "not available" plus a self-assessment fallback — they never crash
 the app.
 
-**Genie Spaces (pillar 5):** Genie Spaces have their own ACLs. The app needs
-`CAN_RUN` on a space to **list and count** it. Reading a space's **curation
+**Genie Agents (pillar 5):** Genie Agents have their own ACLs. The app needs
+`CAN_RUN` on an agent to **list and count** it. Reading an agent's **curation
 detail** (instructions, sample questions, example/verified SQL, functions,
-benchmarks) comes from the space's serialized definition, which Databricks gates
-behind **`CAN_EDIT`** — so the per-space curation breakdown is best-effort: the
-app assesses whatever spaces it can read and reports the rest as "curation not
+benchmarks) comes from the agent's serialized definition, which Databricks gates
+behind **`CAN_EDIT`** — so the per-agent curation breakdown is best-effort: the
+app assesses whatever agents it can read and reports the rest as "curation not
 assessed (needs CAN_EDIT)" rather than as uncurated. Granting an app SP
-`CAN_EDIT` across every space is a heavy ask; for a lighter footprint, grant
+`CAN_EDIT` across every agent is a heavy ask; for a lighter footprint, grant
 `CAN_RUN` (counts only) and rely on the self-assessment for curation depth, or
 have an editor run the deep pass.
 
@@ -146,7 +146,7 @@ databricks.yml               — DABs: app + sql-warehouse resource
 ## Readiness pillars (each scored 0-4)
 
 Unity Catalog Foundation · Metadata Richness · Relationships & Modeling ·
-Semantic Layer (Business Semantics) · Genie Spaces · Domains & Stewardship ·
+Metrics · Genie Agents · Domains & Stewardship ·
 Adoption & Activity. The overall score maps to a **Genie Foundations** session
 ("Ready for Session 2 — Genie Room Setup", etc.).
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A self-contained Databricks App that helps a customer **prepare for Genie Ontolo
 Deploy it into a workspace and it will:
 
 - **Assess** the live environment and score maturity across the readiness pillars
-  Genie Ontology depends on (Unity Catalog, metadata, relationships, metric views /
-  Business Semantics, Genie Spaces, domains, adoption).
+  Genie Ontology depends on (Unity Catalog, metadata, relationships, metrics /
+  metric views, Genie Agents, domains, adoption).
 - **Explain** each capability from a **technical** and a **business** standpoint, with
   accurate GA / preview status.
 - **Recommend** best practices for both technical enablement and business adoption.
@@ -73,9 +73,9 @@ ways, and **every signal uses the same identity**:
 | Assessment area | Reads from | Grant needed (held by the **viewer** under OBO, or by the **SP** when unattended) |
 |---|---|---|
 | Run any query | SQL warehouse | `CAN USE` on the warehouse |
-| UC Foundation · Metadata · Relationships · Semantic Layer · Domains (tags) | catalog / `system.information_schema` | `BROWSE` on each assessed catalog (metadata-only, least privilege) — or `USE CATALOG`+`USE SCHEMA`+`SELECT` |
+| UC Foundation · Metadata · Relationships · Metrics · Domains (tags) | catalog / `system.information_schema` | `BROWSE` on each assessed catalog (metadata-only, least privilege) — or `USE CATALOG`+`USE SCHEMA`+`SELECT` |
 | "Not in Unity Catalog" coverage | `hive_metastore.information_schema` | read on `hive_metastore` (if legacy access is enabled) |
-| Genie Spaces (count + activity) | `system.access.audit` (`aibiGenie` events) | `USE`+`SELECT` on `system.access` |
+| Genie Agents (count + activity) | `system.access.audit` (`aibiGenie` events) | `USE`+`SELECT` on `system.access` |
 | Adoption & Activity | `system.access.audit`, `system.query.history` | `USE`+`SELECT` on `system.access` and `system.query` |
 | Top‑10 most‑accessed + certified | `system.access.table_lineage` + `information_schema.table_tags` | `USE`+`SELECT` on `system.access` + catalog metadata |
 | Plan / Assistant (LLM) | Foundation Model API | model serving / FMAPI enabled for the workspace |

--- a/app/accelerators/ai-ready-semantics/building-ai-ready-semantics.md
+++ b/app/accelerators/ai-ready-semantics/building-ai-ready-semantics.md
@@ -1,11 +1,11 @@
 # Building AI-Ready Business Semantics
 
-A practical, self-guided method for curating **metric views**, **Genie Spaces**, and
+A practical, self-guided method for curating **metric views**, **Genie Agents**, and
 the **governed tags/domains** that make them discoverable — so an AI agent answers
 your business questions accurately and consistently.
 
 Trustworthy talk-to-data rests on a unified, curated semantic foundation. Metric
-views and Genie Spaces are the tools for building it, but they only pay off with
+views and Genie Agents are the tools for building it, but they only pay off with
 deliberate curation: the integrity of the numbers, the richness of the metadata,
 and the discipline of testing are what separate a demo from something a business
 team relies on.
@@ -30,7 +30,7 @@ roadmaps. Both describe the same five-phase process; edit them together.
 
 - The fact and dimension tables behind each KPI, governed in Unity Catalog.
 - Source documentation and the data model (tables and their relationships).
-- Permission to create metric views and Genie Spaces.
+- Permission to create metric views and Genie Agents.
 - If you are migrating an existing BI semantic model: the measure definitions and
   the reports that consume them, so nothing is silently dropped.
 
@@ -45,9 +45,9 @@ a loop you stay in as the semantic layer grows.
 |---|---|
 | 1. Prepare | A scoped KPI list mapped to its Unity Catalog sources of truth. |
 | 2. Build the semantic layer | Governed metric views — one fact source each — with rich metadata. |
-| 3. Organize by domain | Genie Spaces and metric views structured around the business. |
+| 3. Organize by domain | Genie Agents and metric views structured around the business. |
 | 4. Test incrementally | Validated measures, saved example SQL, and question benchmarks. |
-| 5. Validate & release | Regression-tested spaces, piloted with real users, feedback looping back. |
+| 5. Validate & release | Regression-tested agents, piloted with real users, feedback looping back. |
 
 ---
 
@@ -82,7 +82,7 @@ spans multiple fact tables or contains nested logic, build a **base view** first
 > unaggregated, row-level data, so the agent still has to infer the aggregation and
 > may get it wrong. A metric view **pre-defines** the aggregation, which cuts
 > hallucination risk. Once the metric view exists, **remove the raw base view and
-> tables from the Genie Space** and expose only the metric view — keeping both
+> tables from the Genie Agent** and expose only the metric view — keeping both
 > creates redundancy and ambiguity.
 
 ### Building it up
@@ -124,18 +124,18 @@ spans multiple fact tables or contains nested logic, build a **base view** first
 
 ## Phase 3 — Organize by domain, not by report
 
-**Goal: structure Genie Spaces and metric views around the business.**
+**Goal: structure Genie Agents and metric views around the business.**
 
-- **Genie Space = a business domain or subdomain** (for example, "Online
+- **Genie Agent = a business domain or subdomain** (for example, "Online
   Marketing"). **Metric view = a KPI group** within it (for example, "Conversion
   Metrics").
 - Name metric views by convention: `{subdomain}_{kpi_group}`.
-- **Tag** Genie Spaces and metric views with their domain/subdomain for
+- **Tag** Genie Agents and metric views with their domain/subdomain for
   discoverability and observability. Optionally mirror the structure in Unity
   Catalog — one schema per domain or subdomain.
-- Keep each space focused. A Genie Space supports up to **30** tables/views/metric
+- Keep each agent focused. A Genie Agent supports up to **30** tables/views/metric
   views, and the tighter the domain, the better the agent performs. As you approach
-  the limit, split the domain into more granular subdomain spaces.
+  the limit, split the domain into more granular subdomain agents.
 
 ---
 
@@ -143,18 +143,18 @@ spans multiple fact tables or contains nested logic, build a **base view** first
 
 **Goal: onboard one measure at a time, prove it, and capture what works.**
 
-- Add **one measure** to the space, ask sample questions, and validate the answer
+- Add **one measure** to the agent, ask sample questions, and validate the answer
   before adding the next.
-- Save each validated query as an **example SQL query** in the space so the agent
+- Save each validated query as an **example SQL query** in the agent so it
   reuses it or learns from it. Keep example SQL **simple** — prefer `WHERE` over
   `CASE`; complexity adds to the agent's reasoning load.
 - Leave **prompt matching** enabled on columns so the agent maps user language to
   real values and tolerates misspellings. For ambiguous categorical values, add
   exact-match filter instructions.
-- Always give the **space itself a name and a description**. Routing across multiple
-  spaces (and multi-agent setups) depends on the description to delegate a question
-  to the right space — without one, an orchestrating agent cannot reliably choose.
-- Structure space instructions as: **(1) trigger condition** — when the user asks
+- Always give the **agent itself a name and a description**. Routing across multiple
+  agents (and multi-agent setups) depends on the description to delegate a question
+  to the right agent — without one, an orchestrating agent cannot reliably choose.
+- Structure agent instructions as: **(1) trigger condition** — when the user asks
   about X; **(2) required action** — then always do Y; **(3) example** — a sample
   question and the expected behavior.
 
@@ -174,12 +174,12 @@ or easy to misread. Repeat for each KPI until the whole KPI group is covered.
 - **Re-run all benchmarks after every change** — a new measure, a new instruction.
   If a previously passing benchmark now fails, the latest addition is the likely
   cause. Use the failure analysis and fix-review tools to diagnose it.
-- Regression testing is **per space** — adding a new space does not affect existing
-  ones. If you connect multiple spaces (a supervisor or custom multi-agent system),
-  also test the **cross-space** interactions.
-- **Pilot with business users.** Share the curated space, and have testers use the
+- Regression testing is **per agent** — adding a new agent does not affect existing
+  ones. If you connect multiple agents (a supervisor or custom multi-agent system),
+  also test the **cross-agent** interactions.
+- **Pilot with business users.** Share the curated agent, and have testers use the
   built-in feedback to flag and comment on responses. Keep conversations
-  **reviewable by space managers** so curators can see the feedback — a private
+  **reviewable by agent managers** so curators can see the feedback — a private
   conversation hides the response from the curator.
 - Feed **both** regression failures and user feedback back into Phase 4. This is a
   loop, not a one-time release.
@@ -203,11 +203,11 @@ Always review generated output before you apply it.
   then the metric view on top.
 - **Validate one measure at a time** against the trusted number.
 - **Comment at view/dimension/measure level**; add **synonyms** and **format specs**.
-- **One Genie Space per domain**, under 30 items, **with a description**.
+- **One Genie Agent per domain**, under 30 items, **with a description**.
 - **Save validated queries as example SQL** and keep it simple.
 - **Instructions:** trigger → action → example.
 - **Benchmark** 2–4 phrasings per question with ground-truth SQL; **regression-test
   after every change**.
-- **Name** metric views `{subdomain}_{kpi_group}`; **tag** spaces and metric views
+- **Name** metric views `{subdomain}_{kpi_group}`; **tag** agents and metric views
   with their domain.
 - **Certify** canonical assets and **name a steward** per domain.

--- a/app/accelerators/genie-space-workbench-workshop/workshop-plan.md
+++ b/app/accelerators/genie-space-workbench-workshop/workshop-plan.md
@@ -1,11 +1,11 @@
-# Genie Space Quality Workshop
+# Genie Agent Quality Workshop
 
-**Take one Genie Space from cold‑start failures to a trusted, benchmarked, production‑ready space in a half day — and leave with a repeatable playbook for the rest.**
+**Take one Genie Agent from cold‑start failures to a trusted, benchmarked, production‑ready agent in a half day — and leave with a repeatable playbook for the rest.**
 
-A brand‑new Genie Space with just a table and a question usually fails: no
+A brand‑new Genie Agent with just a table and a question usually fails: no
 descriptions, no instructions, no examples, no benchmarks — so business users
 lose trust before they start. This workshop uses the open‑source **Genie
-Workbench** app to score a space, benchmark it against *your own* questions, and
+Workbench** app to score an agent, benchmark it against *your own* questions, and
 run a guided fix + auto‑optimize loop with measurable proof of lift.
 
 > **Want this facilitated?** Ask your Databricks account team to run this
@@ -17,15 +17,15 @@ run a guided fix + auto‑optimize loop with measurable proof of lift.
 
 ## Who should be in the room
 
-- **A BI developer / data engineer** who owns the space's data model and can edit it.
+- **A BI developer / data engineer** who owns the agent's data model and can edit it.
 - **One to three business power users** who know what a *correct* answer looks like and can validate results.
 
 ## What you'll walk away with
 
-- A **scored, versioned Genie Space** that reaches the "Trusted" maturity tier.
+- A **scored, versioned Genie Agent** that reaches the "Trusted" maturity tier.
 - **≥ 85% benchmark accuracy** on your tier‑1, deal‑breaker questions.
 - **Proof of lift** (baseline vs. optimized) captured with MLflow.
-- A **reproducible playbook** — with named owners — to roll to your next 2–3 spaces.
+- A **reproducible playbook** — with named owners — to roll to your next 2–3 agents.
 
 ---
 
@@ -33,10 +33,10 @@ run a guided fix + auto‑optimize loop with measurable proof of lift.
 
 1. **Deploy Genie Workbench** as a Databricks App in your workspace — it's open
    source (repo linked in *Resources* below).
-2. **Pick one Genie Space** backed by a real data model. 5–7 tables is ideal;
+2. **Pick one Genie Agent** backed by a real data model. 5–7 tables is ideal;
    fewer than 16 is strongly preferred (there is a 30‑table hard limit).
 3. **Prepare 10–20 benchmark questions** with the expected answer or expected SQL
-   for each. This is the single most common gap and the top reason spaces fail —
+   for each. This is the single most common gap and the top reason agents fail —
    don't skip it.
 4. **Do baseline curation** where it's obvious: add table/column descriptions,
    define join relationships, and hide internal/staging tables.
@@ -45,24 +45,24 @@ run a guided fix + auto‑optimize loop with measurable proof of lift.
 
 | # | Step | Time | What happens |
 |---|------|------|--------------|
-| 1 | **Use‑case discovery** | 30 min | Frame the business questions the space must answer. Surface the definition layer (how revenue is calculated, what counts as "active"), access constraints (row‑level security, multi‑tenancy), and the decisions users make from these answers today. |
+| 1 | **Use‑case discovery** | 30 min | Frame the business questions the agent must answer. Surface the definition layer (how revenue is calculated, what counts as "active"), access constraints (row‑level security, multi‑tenancy), and the decisions users make from these answers today. |
 | 2 | **Benchmark questions & "what good looks like"** | 45 min | Power users walk their 10–20 questions; capture expected SQL/answers and tag the ~5 tier‑1 deal‑breakers. Load the suite into Workbench. |
 | 3 | **Scan + deep analysis** | 45 min | Run the deterministic checks and the LLM‑evaluated assessment. Whiteboard the priority order: **data model → knowledge store → SQL examples → instructions.** |
 | — | *Break* | 15 min | |
 | 4 | **Fix + power‑user curation** | 60 min | The BI developer runs the fix step; power users review each proposed patch in a side‑by‑side diff and **accept / modify / reject** — the customer team authors the config. |
-| 5 | **Auto‑optimize, validate & playbook** | 60 min | Kick off the optimization loop (LLM‑judged, with auto‑rollback). While it runs, cover production architecture (entity matching, token budget, scaling, ops). Then A/B compare baseline vs. optimized on the tier‑1 questions, review the proof of lift, and write the playbook for the next spaces. |
+| 5 | **Auto‑optimize, validate & playbook** | 60 min | Kick off the optimization loop (LLM‑judged, with auto‑rollback). While it runs, cover production architecture (entity matching, token budget, scaling, ops). Then A/B compare baseline vs. optimized on the tier‑1 questions, review the proof of lift, and write the playbook for the next agents. |
 
 ## Success metrics
 
 - Maturity score moves from baseline → **Trusted** tier.
 - **≥ 85%** accuracy on tier‑1 deal‑breaker questions.
-- Business users are querying the optimized space **within 30 days**.
-- The playbook is rolled to **2–3 more spaces within 60 days**.
+- Business users are querying the optimized agent **within 30 days**.
+- The playbook is rolled to **2–3 more agents within 60 days**.
 
 ## Good to know (current limitations)
 
-- **30‑table hard limit** per space; denormalize aggressively — wide/pre‑joined views beat many small tables.
-- **Don't mix metric views and regular tables** in the same space.
+- **30‑table hard limit** per agent; denormalize aggressively — wide/pre‑joined views beat many small tables.
+- **Don't mix metric views and regular tables** in the same agent.
 - There is a **per‑minute query rate limit** — design for it when planning rollout.
 - Genie Workbench uses **Claude Sonnet via the Foundation Model API** — make sure that's available in your workspace.
 
@@ -71,12 +71,12 @@ run a guided fix + auto‑optimize loop with measurable proof of lift.
 ## Resources (all public)
 
 - **Genie Workbench (open source):** https://github.com/databricks-solutions/databricks-genie-workbench
-- **Getting your Genie Spaces production-ready with Genie Workbench (Medium):** https://medium.com/@jenny.j.park/getting-your-genie-spaces-production-ready-with-genie-workbench-e9e7db8a88ca
-- **Curate an effective Genie Space (docs):** https://docs.databricks.com/aws/en/genie/best-practices
-- **Create and manage a Genie Space (docs):** https://docs.databricks.com/aws/en/genie/set-up
+- **Getting your Genie Agents production-ready with Genie Workbench (Medium):** https://medium.com/@jenny.j.park/getting-your-genie-spaces-production-ready-with-genie-workbench-e9e7db8a88ca
+- **Curate an effective Genie Agent (docs):** https://docs.databricks.com/aws/en/genie/best-practices
+- **Create and manage a Genie Agent (docs):** https://docs.databricks.com/aws/en/genie/set-up
 - **Build a knowledge store for Genie (docs):** https://docs.databricks.com/aws/en/genie/knowledge-store
 - **From Data to Dialogue — best‑practices guide (blog):** https://www.databricks.com/blog/data-dialogue-best-practices-guide-building-high-performing-genie-spaces
-- **How to build production‑ready Genie Spaces (blog):** https://www.databricks.com/blog/how-build-production-ready-genie-spaces-and-build-trust-along-way
+- **How to build production‑ready Genie Agents (blog):** https://www.databricks.com/blog/how-build-production-ready-genie-spaces-and-build-trust-along-way
 - **Building confidence with benchmarks & Ask Review (blog):** https://www.databricks.com/blog/building-confidence-your-genie-space-benchmarks-and-ask-review
 
 ---

--- a/app/frontend/__tests__/accelerators.test.tsx
+++ b/app/frontend/__tests__/accelerators.test.tsx
@@ -24,7 +24,7 @@ const CAPABILITY_KEYS = [
   'metadata',
   'relationships',
   'metric_views',
-  'genie_spaces',
+  'genie_agents',
   'domains',
   'adoption',
 ] as const;

--- a/app/frontend/src/components/GenieTester.tsx
+++ b/app/frontend/src/components/GenieTester.tsx
@@ -4,7 +4,7 @@ import { apiGet, apiPost } from '../hooks/useApi';
 import type { GenieSpace, GenieSpacesResponse, GenieResult } from '../types';
 import Spinner from './Spinner';
 
-// "Test a question" widget shown inside the Genie Spaces pillar when a Genie
+// "Test a question" widget shown inside the Genie Agents pillar when a Genie
 // space is configured. Starts a conversation and renders the SQL + result grid.
 export default function GenieTester() {
   const [spaces, setSpaces] = useState<GenieSpace[]>([]);
@@ -71,7 +71,7 @@ export default function GenieTester() {
           value={question}
           onChange={(e) => setQuestion(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && ask()}
-          placeholder="Ask the Genie space a question..."
+          placeholder="Ask the Genie agent a question..."
           className="flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-databricks-300"
         />
         <button onClick={ask} disabled={loading} className="btn-primary py-1.5 px-3 flex items-center gap-1">

--- a/app/frontend/src/components/HelpButton.tsx
+++ b/app/frontend/src/components/HelpButton.tsx
@@ -21,8 +21,8 @@ const REQUIREMENTS: { label: string; detail: string }[] = [
     detail: 'Model serving enabled — powers the guided Plan conversation and the generated action plan (and the model picker in the header).',
   },
   {
-    label: 'Genie Spaces (optional)',
-    detail: 'Grant the app SP CAN_RUN to list and count spaces; CAN_EDIT to assess curation depth (instructions, example SQL, benchmarks, functions).',
+    label: 'Genie Agents (optional)',
+    detail: 'Grant the app SP CAN_RUN to list and count agents; CAN_EDIT to assess curation depth (instructions, example SQL, benchmarks, functions).',
   },
   {
     label: 'Lakebase (optional)',

--- a/app/frontend/src/components/PillarDetail.tsx
+++ b/app/frontend/src/components/PillarDetail.tsx
@@ -63,7 +63,7 @@ function GenieSpacesTable({ spaces }: { spaces: GenieSpaceCuration[] }) {
         <table className="w-full text-sm">
           <thead>
             <tr className="bg-gray-50 text-left">
-              <th className="px-3 py-2 text-xs font-semibold text-ink-600">Genie Space</th>
+              <th className="px-3 py-2 text-xs font-semibold text-ink-600">Genie Agent</th>
               {GENIE_COLS.map((c) => (
                 <th key={c.key} className="px-3 py-2 text-xs font-semibold text-ink-600 text-center whitespace-nowrap">
                   {c.label}
@@ -178,13 +178,13 @@ export default function PillarDetail({
           <LegacyBreakdown rows={pillar.metrics.legacy_by_schema as UcSchemaCount[]} />
         )}
 
-      {pillar.key === 'genie_spaces' &&
+      {pillar.key === 'genie_agents' &&
         Array.isArray(pillar.metrics?.spaces) &&
         (pillar.metrics.spaces as GenieSpaceCuration[]).length > 0 && (
           <GenieSpacesTable spaces={pillar.metrics.spaces as GenieSpaceCuration[]} />
         )}
 
-      {pillar.key === 'genie_spaces' && config.genie_space_configured && (
+      {pillar.key === 'genie_agents' && config.genie_space_configured && (
         <GenieTester />
       )}
     </div>

--- a/app/frontend/src/components/Scorecard.tsx
+++ b/app/frontend/src/components/Scorecard.tsx
@@ -70,7 +70,7 @@ function fmtWhen(iso: string): string {
 }
 
 // Wrap a pillar name to <=~16-char lines so long titles like
-// "Semantic Layer (Business Semantics)" don't clip off the radar chart.
+// "Relationships & Modeling" don't clip off the radar chart.
 function wrapLabel(text: string, maxChars = 16): string[] {
   const words = text.split(' ');
   const lines: string[] = [];
@@ -294,7 +294,7 @@ export default function Scorecard({
         <h2 className="text-xl font-bold text-ink-900">Assess your Genie Ontology readiness</h2>
         <p className="text-sm text-ink-600 mt-2 leading-relaxed">
           This reads your Unity Catalog metadata (catalogs, comments, constraints, metric views,
-          Genie Spaces, tags) to score your readiness across seven pillars. It runs read-only as the
+          Genie Agents, tags) to score your readiness across seven pillars. It runs read-only as the
           app's service principal and typically takes 30–60 seconds.
         </p>
       </div>
@@ -307,9 +307,9 @@ export default function Scorecard({
         <p className="text-sm text-ink-700 leading-relaxed">
           Genie Ontology is the business-aware context layer that lets Genie answer from your
           <span className="font-medium"> authoritative </span> source instead of guessing. It combines
-          the context you govern and certify — metric views, domains, and a business glossary — with
+          the context you govern and certify — metric views, domains, and Pages — with
           context Genie learns from the assets you already have (dashboards, saved queries, Genie
-          Spaces), and ranks every signal by authority so answers stay accurate, governed, and
+          Agents), and ranks every signal by authority so answers stay accurate, governed, and
           permission-aware. Getting ready for it means maturing that governed foundation, which is
           exactly what this assessment measures.
         </p>
@@ -324,7 +324,7 @@ export default function Scorecard({
           <li className="flex items-start gap-2"><span className="text-ink-300 mt-0.5">•</span><span>A workspace with <span className="font-medium">Unity Catalog</span> enabled.</span></li>
           <li className="flex items-start gap-2"><span className="text-ink-300 mt-0.5">•</span><span>A <span className="font-medium">SQL warehouse</span> for the read-only metadata queries.</span></li>
           <li className="flex items-start gap-2"><span className="text-ink-300 mt-0.5">•</span><span>Read access for the app's <span className="font-medium">service principal</span>: <code className="text-xs">USE CATALOG</code> / <code className="text-xs">USE SCHEMA</code> / <code className="text-xs">SELECT</code> on <code className="text-xs">system.information_schema</code>, <code className="text-xs">system.access</code>, <code className="text-xs">system.query</code>, plus the catalogs you want assessed. Deploy applies these automatically; it falls back to each catalog's own <code className="text-xs">information_schema</code> if system tables aren't granted.</span></li>
-          <li className="flex items-start gap-2"><span className="text-ink-300 mt-0.5">•</span><span><span className="font-medium">Optional:</span> <code className="text-xs">CAN_RUN</code> on your Genie Spaces so the Genie pillar can count and assess them.</span></li>
+          <li className="flex items-start gap-2"><span className="text-ink-300 mt-0.5">•</span><span><span className="font-medium">Optional:</span> <code className="text-xs">CAN_RUN</code> on your Genie Agents so the Genie pillar can count and assess them.</span></li>
           <li className="flex items-start gap-2"><span className="text-ink-300 mt-0.5">•</span><span>The <span className="font-medium">Plan</span> tab additionally uses your workspace's Foundation Model API to generate a plan against a saved assessment.</span></li>
         </ul>
         <p className="text-xs text-ink-400 mt-2.5">

--- a/app/server/assessment/probes.py
+++ b/app/server/assessment/probes.py
@@ -459,7 +459,7 @@ async def probe_relationships() -> dict:
 # ---------------------------------------------------------------------------
 # 4. Semantic layer (metric views)
 # ---------------------------------------------------------------------------
-async def probe_semantic_layer() -> dict:
+async def probe_metrics() -> dict:
     s = await _resolve_sources()
     tbl = _src("tables", s)
     if tbl is None:
@@ -483,7 +483,7 @@ async def probe_semantic_layer() -> dict:
             return {
                 "available": True,
                 "score": 0.0,
-                "signals": [{"label": "Metric views", "value": 0, "detail": "UC metric views (Business Semantics)"}],
+                "signals": [{"label": "Metric views", "value": 0, "detail": "UC metric views"}],
                 "gaps": ["No metric views found. Metric views are the GA foundation that feeds Genie Ontology — define KPIs centrally here."],
                 "note": None,
                 "metrics": {"metric_views": 0},
@@ -509,7 +509,7 @@ async def probe_semantic_layer() -> dict:
 
         # Build signals
         signals = [
-            {"label": "Metric views", "value": metric_views, "detail": "UC metric views (Business Semantics)"}
+            {"label": "Metric views", "value": metric_views, "detail": "UC metric views"}
         ]
         if metric_views > 0:
             signals.append({
@@ -539,12 +539,12 @@ async def probe_semantic_layer() -> dict:
             "metrics": {"metric_views": metric_views, "metric_views_commented": commented},
         }
     except Exception as e:
-        logger.warning(f"probe_semantic_layer failed: {e}")
+        logger.warning(f"probe_metrics failed: {e}")
         return _empty(f"Could not count metric views ({str(e)[:120]}).")
 
 
 # ---------------------------------------------------------------------------
-# 5. Genie Spaces (REST) — deep curation assessment
+# 5. Genie Agents (REST) — deep curation assessment
 # ---------------------------------------------------------------------------
 _MAX_INSPECT = 30  # cap how many spaces we deep-inspect to bound latency
 
@@ -606,16 +606,16 @@ async def _inspect_space(host: str, headers: dict, sid: str, title: str) -> tupl
 # Reading a space's curation (serialized_space) requires CAN_EDIT; listing/asking
 # only needs CAN_RUN. So the deep per-space breakdown is best-effort: we assess
 # whatever the app can read and never report a space we can't read as "uncurated".
-_EDIT_HINT = ("Reading a space's curation detail requires CAN_EDIT on that space; the app only needs "
-              "CAN_RUN to list and count spaces. Grant the app service principal CAN_EDIT on the "
-              "spaces you want curation-assessed (or run this assessment as a user who can edit them).")
+_EDIT_HINT = ("Reading an agent's curation detail requires CAN_EDIT on that agent; the app only needs "
+              "CAN_RUN to list and count agents. Grant the app service principal CAN_EDIT on the "
+              "agents you want curation-assessed (or run this assessment as a user who can edit them).")
 
 
 async def _genie_audit_counts() -> dict:
     """Best-effort Genie usage from the audit system table.
 
     system.access.audit records Genie activity under service_name='aibiGenie'
-    with the space id in request_params.space_id. The count of Genie Spaces is
+    with the space id in request_params.space_id. The count of Genie Agents is
     the number of distinct space_ids, excluding any space that has ever been
     trashed (a `trashSpace` action; there is no deleteSpace — see the docs at
     https://docs.databricks.com/aws/en/ai-bi/admin/audit).
@@ -650,16 +650,16 @@ async def _genie_audit_counts() -> dict:
 def _genie_audit_signals(audit: dict) -> list:
     sig = []
     if audit.get("total") is not None:
-        sig.append({"label": "Genie Spaces", "value": audit["total"],
-                    "detail": "Distinct existing spaces in system.access.audit (aibiGenie)"})
+        sig.append({"label": "Genie Agents", "value": audit["total"],
+                    "detail": "Distinct existing agents in system.access.audit (aibiGenie)"})
     if audit.get("active_30d") is not None:
-        sig.append({"label": "Active spaces (30d)", "value": audit["active_30d"],
-                    "detail": "Distinct spaces with activity in the last 30 days — audit log"})
+        sig.append({"label": "Active agents (30d)", "value": audit["active_30d"],
+                    "detail": "Distinct agents with activity in the last 30 days — audit log"})
     return sig
 
 
-async def probe_genie_spaces() -> dict:
-    """Count Genie Spaces from the audit log ONLY (system.access.audit / aibiGenie).
+async def probe_genie_agents() -> dict:
+    """Count Genie Agents from the audit log ONLY (system.access.audit / aibiGenie).
 
     We deliberately do not use the Genie REST API "spaces visible to the app": it is
     permission- and scope-gated (on-behalf-of-user tokens lack the genie scope), and
@@ -683,9 +683,9 @@ async def probe_genie_spaces() -> dict:
 
     gaps = []
     if total == 0:
-        gaps.append("No Genie Spaces found in the audit log — create a curated Genie Space as the entry point to natural-language analytics.")
+        gaps.append("No Genie Agents found in the audit log — create a curated Genie Agent as the entry point to natural-language analytics.")
     elif active == 0:
-        gaps.append(f"{total} Genie Space(s) exist but none were active in the last 30 days — drive adoption or retire stale spaces.")
+        gaps.append(f"{total} Genie Agent(s) exist but none were active in the last 30 days — drive adoption or retire stale agents.")
 
     return {
         "available": True,
@@ -694,8 +694,8 @@ async def probe_genie_spaces() -> dict:
         "gaps": gaps,
         "note": "Counted from system.access.audit (aibiGenie). Curation quality — instructions, "
                 "example/verified SQL, benchmarks — isn't visible in the audit log; use the "
-                "Genie Space Quality Workshop accelerator to assess and lift it.",
-        "metrics": {"genie_spaces": total, "active_30d": active, "genie_audit": audit},
+                "Genie Agent Quality Workshop accelerator to assess and lift it.",
+        "metrics": {"genie_agents": total, "active_30d": active, "genie_audit": audit},
     }
 
 
@@ -962,8 +962,8 @@ PROBES = {
     "uc_foundation": probe_uc_foundation,
     "metadata": probe_metadata,
     "relationships": probe_relationships,
-    "semantic_layer": probe_semantic_layer,
-    "genie_spaces": probe_genie_spaces,
+    "metrics": probe_metrics,
+    "genie_agents": probe_genie_agents,
     "domains": probe_domains,
     "adoption": probe_adoption,
 }

--- a/app/server/config.py
+++ b/app/server/config.py
@@ -60,7 +60,7 @@ USE_LAKEBASE = os.environ.get("USE_LAKEBASE", "false").lower() == "true"
 # Workspace id (for building deep links into the customer's workspace UI)
 WORKSPACE_ID = os.environ.get("WORKSPACE_ID", "")
 
-# Optional Genie space to test answer quality against (pillar 5)
+# Optional Genie agent to test answer quality against (pillar 5)
 GENIE_SPACE_ID = os.environ.get("GENIE_SPACE_ID", "")
 
 # Cache workspace client to avoid repeated creation

--- a/app/server/content/accelerators.py
+++ b/app/server/content/accelerators.py
@@ -434,7 +434,7 @@ ACCELERATORS: list[dict] = [
         },
         "valid_as_of": "2026-07",
     },
-    # ---- Metrics / Metric Views (weight 18) -------------------------
+    # ---- Metrics / Metric Views (weight 20) -------------------------
     {
         # Build accelerator (per plan §3): scaffold metric-view YAML from a KPI
         # inventory or query history — a hand-authored complement to the

--- a/app/server/content/accelerators.py
+++ b/app/server/content/accelerators.py
@@ -23,7 +23,7 @@ ACCELERATORS: list[dict] = [
         # certification-ready, metric views, FK) — listed first for customers.
         "key": "metadata-dbxmetagen",
         "title": "dbxmetagen — AI metadata, tags, certification & metric-view generator",
-        "summary": "Databricks Industry Solutions toolkit that auto-generates comments, PII/domain tags, metric views, FK predictions, and even Genie spaces across Unity Catalog — the fastest way to enrich metadata at scale.",
+        "summary": "Databricks Industry Solutions toolkit that auto-generates comments, PII/domain tags, metric views, FK predictions, and even Genie agents across Unity Catalog — the fastest way to enrich metadata at scale.",
         "capability": "metadata",
         "type": "repo",
         "effort": "Half a day to pilot on a schema",
@@ -32,9 +32,9 @@ ACCELERATORS: list[dict] = [
             "metadata at scale across several modes: comment generation (tables/columns), PI mode "
             "(classify + tag PII/PHI/PCI as governed tags), domain classification, data profiling and "
             "quality scoring, AI-assisted foreign-key prediction, and a semantic-layer mode that "
-            "auto-generates metric views and provisions Genie spaces from a knowledge base. Because it "
+            "auto-generates metric views and provisions Genie agents from a knowledge base. Because it "
             "writes comments, governed tags, and metric views, it lifts the Metadata, Domains, "
-            "Relationships, and Semantic Layer pillars at once — and its outputs are a strong base for "
+            "Relationships, and Metrics pillars at once — and its outputs are a strong base for "
             "certifying your canonical assets. Review AI-generated metadata before applying."
         ),
         "prerequisites": [
@@ -43,7 +43,7 @@ ACCELERATORS: list[dict] = [
             "MODIFY on the target catalog to apply comments/tags; ASSIGN on governed tags to tag",
             "A steward to review generated metadata before it is applied",
         ],
-        "improves_signals": ["metadata", "domains", "relationships", "semantic_layer"],
+        "improves_signals": ["metadata", "domains", "relationships", "metric_views"],
         "target_level": 4,
         "review_mode": True,
         "steps": [
@@ -62,14 +62,14 @@ ACCELERATORS: list[dict] = [
     {
         "key": "semantic-dbxmetagen",
         "title": "dbxmetagen — auto-generate metric views (semantic layer)",
-        "summary": "Use dbxmetagen's semantic-layer mode to auto-generate Unity Catalog metric views (measures, dimensions, join paths) — and even provision Genie spaces — from your documented catalog.",
+        "summary": "Use dbxmetagen's semantic-layer mode to auto-generate Unity Catalog metric views (measures, dimensions, join paths) — and even provision Genie agents — from your documented catalog.",
         "capability": "metric_views",
         "type": "repo",
         "effort": "~1-2 hours per subject area",
         "what_it_does": (
             "dbxmetagen's semantic-layer mode reads your tables (and any comments / tags it generated) and "
             "drafts Unity Catalog metric views — measures, dimensions, and join paths — plus example SQL, "
-            "and can provision a Genie space from the knowledge base. It turns a documented catalog into a "
+            "and can provision a Genie agent from the knowledge base. It turns a documented catalog into a "
             "queryable semantic layer far faster than authoring metric views by hand. Always review the "
             "generated measure logic with a business owner before publishing."
         ),
@@ -88,8 +88,8 @@ ACCELERATORS: list[dict] = [
             "Run comment/domain modes first so the LLM has business context (optional but recommended).",
             "Run the semantic-layer mode to draft metric views (measures, dimensions, joins) + example SQL.",
             "Review the generated metric-view definitions with a business owner; correct measure logic and names.",
-            "Publish the approved metric views (and optionally the generated Genie space).",
-            "Re-run the readiness assessment — the Semantic Layer pillar should rise.",
+            "Publish the approved metric views (and optionally the generated Genie agent).",
+            "Re-run the readiness assessment — the Metrics pillar should rise.",
         ],
         "source": {
             "title": "dbxmetagen (Databricks Industry Solutions, GitHub)",
@@ -244,37 +244,37 @@ ACCELERATORS: list[dict] = [
         # docs/blogs) and the bundled plan is a shareable leave-behind — no
         # internal go/ links, tickets, Slack, or field-only material.
         "key": "genie-space-workbench-workshop",
-        "title": "Genie Space Quality Workshop (Genie Workbench)",
-        "summary": "A guided half-day that takes one Genie Space from cold-start failures to 85%+ benchmark accuracy — scored, optimized, and production-ready — using the open-source Genie Workbench app.",
-        "capability": "genie_spaces",
+        "title": "Genie Agent Quality Workshop (Genie Workbench)",
+        "summary": "A guided half-day that takes one Genie Agent from cold-start failures to 85%+ benchmark accuracy — scored, optimized, and production-ready — using the open-source Genie Workbench app.",
+        "capability": "genie_agents",
         "type": "repo",
         "effort": "Half a day (facilitated)",
         "what_it_does": (
-            "Genie Workbench is an open-source Databricks App that scores a Genie Space against "
+            "Genie Workbench is an open-source Databricks App that scores a Genie Agent against "
             "deterministic and LLM-evaluated checks, benchmarks it against your own question set, and "
             "runs a guided fix + auto-optimize loop with proof of lift. In a half-day workshop your BI "
-            "developer and business power users take one space from failing answers to a trusted, "
-            "benchmarked, versioned space — and leave with a reproducible playbook for the next 2-3 "
-            "spaces. Download the workshop plan below to line up the right people, then engage your "
+            "developer and business power users take one agent from failing answers to a trusted, "
+            "benchmarked, versioned agent — and leave with a reproducible playbook for the next 2-3 "
+            "agents. Download the workshop plan below to line up the right people, then engage your "
             "Databricks account team to facilitate the session."
         ),
         "prerequisites": [
             "Deploy Genie Workbench as a Databricks App in your workspace (open-source repo, linked below)",
-            "One Genie Space backed by a real data model (5-7 tables ideal, fewer than 16 preferred; 30-table hard limit)",
+            "One Genie Agent backed by a real data model (5-7 tables ideal, fewer than 16 preferred; 30-table hard limit)",
             "10-20 benchmark questions with expected answers or SQL, prepared by business power users",
             "A Foundation Model API endpoint (Genie Workbench uses Claude Sonnet)",
             "Baseline curation where obvious: table/column descriptions, join relationships, hidden internal tables",
         ],
-        "improves_signals": ["genie_spaces"],
+        "improves_signals": ["genie_agents"],
         "target_level": 4,
         "review_mode": True,
         "steps": [
-            "Use-case discovery — frame the business questions the space must answer and the metric definitions behind them (30 min).",
+            "Use-case discovery — frame the business questions the agent must answer and the metric definitions behind them (30 min).",
             "Benchmark questions — capture expected SQL/answers, tag the tier-1 deal-breakers, and load the suite into Workbench (45 min).",
             "Scan + deep analysis — run the deterministic and LLM-evaluated checks; prioritize data model > knowledge store > SQL examples > instructions (45 min).",
             "Fix + curation — the BI developer runs the fixes; power users accept/modify/reject each patch in the side-by-side diff (60 min).",
             "Auto-optimize + validate — run the optimization loop, A/B compare baseline vs. optimized on the tier-1 questions, and document the playbook (60 min).",
-            "Re-run the readiness assessment — the Genie Spaces pillar should rise as the space reaches the 'Trusted' tier.",
+            "Re-run the readiness assessment — the Genie Agents pillar should rise as the agent reaches the 'Trusted' tier.",
         ],
         "artifact_dir": "genie-space-workbench-workshop",
         "artifact_file": "workshop-plan.md",
@@ -287,19 +287,19 @@ ACCELERATORS: list[dict] = [
     {
         # Customer-facing: Databricks-owned open-source template; public repo only.
         "key": "genie-code-data-product-accelerator",
-        "title": "Data Product Accelerator — Genie Code skills for semantics & Genie Spaces",
-        "summary": "Databricks open-source library of Genie Code / agentic skills that build a governed data product end-to-end, including semantic-layer (metric view) and Genie-space patterns.",
-        "capability": "genie_spaces",
+        "title": "Data Product Accelerator — Genie Code skills for semantics & Genie Agents",
+        "summary": "Databricks open-source library of Genie Code / agentic skills that build a governed data product end-to-end, including semantic-layer (metric view) and Genie-agent patterns.",
+        "capability": "genie_agents",
         "type": "repo",
         "effort": "Guided / skill-driven",
         "what_it_does": (
             "The Data Product Accelerator is a Databricks open-source template of composable "
             "'Genie Code' skills that guide an engineer through building a governed data product: "
             "medallion (bronze/silver/gold) modeling, a semantic layer of metric views, "
-            "Genie-space patterns with agent instructions and benchmark questions, and "
-            "monitoring. Use the semantic-layer and Genie-space skills to stand up well-curated "
-            "metric views and spaces faster and more consistently than authoring them by hand — "
-            "a code-driven complement to the Genie Space Quality Workshop."
+            "Genie-agent patterns with agent instructions and benchmark questions, and "
+            "monitoring. Use the semantic-layer and Genie-agent skills to stand up well-curated "
+            "metric views and agents faster and more consistently than authoring them by hand — "
+            "a code-driven complement to the Genie Agent Quality Workshop."
         ),
         "prerequisites": [
             "Databricks workspace with Unity Catalog",
@@ -307,15 +307,15 @@ ACCELERATORS: list[dict] = [
             "A target schema and the source tables for your data product",
             "A Foundation Model API endpoint for the agentic steps",
         ],
-        "improves_signals": ["genie_spaces", "metric_views"],
+        "improves_signals": ["genie_agents", "metric_views"],
         "target_level": 4,
         "review_mode": False,
         "steps": [
             "Clone the repo and open the data_product_accelerator skills.",
             "Use the semantic-layer skill to define metric views for your core KPIs.",
-            "Use the Genie-space patterns / genai-agents skills to scaffold a curated, well-instructed space with benchmark questions.",
+            "Use the Genie-agent patterns / genai-agents skills to scaffold a curated, well-instructed agent with benchmark questions.",
             "Iterate with the skills' review steps, then publish the objects to Unity Catalog.",
-            "Re-run the readiness assessment — the Genie Spaces (and Metric Views) score should rise.",
+            "Re-run the readiness assessment — the Genie Agents (and Metric Views) score should rise.",
         ],
         "source": {
             "title": "Data Product Accelerator (Databricks, GitHub)",
@@ -325,32 +325,32 @@ ACCELERATORS: list[dict] = [
     },
     {
         "key": "genie-spaces-methodology-guide",
-        "title": "Handbook: curate & benchmark Genie Spaces",
-        "summary": "How to organize Genie Spaces by domain, onboard one measure at a time with example SQL, write trigger→action→example instructions, and benchmark + regression-test. Download the full handbook.",
-        "capability": "genie_spaces",
+        "title": "Handbook: curate & benchmark Genie Agents",
+        "summary": "How to organize Genie Agents by domain, onboard one measure at a time with example SQL, write trigger→action→example instructions, and benchmark + regression-test. Download the full handbook.",
+        "capability": "genie_agents",
         "type": "guide",
         "effort": "Reference / self-guided",
         "what_it_does": (
-            "A well-curated Genie Space has one focused domain/subdomain (≤30 items), always with a description "
+            "A well-curated Genie Agent has one focused domain/subdomain (≤30 items), always with a description "
             "for routing. You save validated queries as example SQL and keep it simple. Instructions are written "
             "as trigger→action→example. Benchmark 2–4 phrasings per question with ground-truth SQL and "
             "regression-test after every change. This guide covers Phases 3–5 of the AI-ready-semantics handbook "
-            "in depth, with techniques for organizing and validating trusted Genie Spaces."
+            "in depth, with techniques for organizing and validating trusted Genie Agents."
         ),
         "prerequisites": [
-            "Create access on Genie Spaces",
-            "Metric views already drafted and available in the space's source catalog",
+            "Create access on Genie Agents",
+            "Metric views already drafted and available in the agent's source catalog",
             "2-4 benchmark questions per KPI with ground-truth SQL",
-            "A business owner to validate space routing and instructions",
+            "A business owner to validate agent routing and instructions",
         ],
-        "improves_signals": ["genie_spaces"],
+        "improves_signals": ["genie_agents"],
         "target_level": 4,
         "review_mode": False,
         "steps": [
-            "Create one Genie Space per business domain/subdomain, keeping under 30 items for performance.",
+            "Create one Genie Agent per business domain/subdomain, keeping under 30 items for performance.",
             "Onboard one metric view at a time; validate its measure against sample questions.",
             "Save validated queries as example SQL; keep the SQL simple to reduce the agent's reasoning load.",
-            "Write space instructions as trigger→action→example for ambiguous or domain-specific logic.",
+            "Write agent instructions as trigger→action→example for ambiguous or domain-specific logic.",
             "Benchmark 2–4 phrasings per question, regression-test after every change, and download the handbook for the full method.",
         ],
         "artifact_dir": "ai-ready-semantics",
@@ -434,7 +434,7 @@ ACCELERATORS: list[dict] = [
         },
         "valid_as_of": "2026-07",
     },
-    # ---- Semantic Layer / Metric Views (weight 22) -------------------------
+    # ---- Metrics / Metric Views (weight 18) -------------------------
     {
         # Build accelerator (per plan §3): scaffold metric-view YAML from a KPI
         # inventory or query history — a hand-authored complement to the
@@ -466,7 +466,7 @@ ACCELERATORS: list[dict] = [
             "Author metric-view YAML stubs (measures, dimensions, join paths, synonyms) for each KPI (see the linked docs).",
             "Review each metric view with a business owner; correct measure logic, names, and synonyms.",
             "Publish the approved metric views to Unity Catalog.",
-            "Re-run the readiness assessment — the Semantic Layer pillar should rise.",
+            "Re-run the readiness assessment — the Metrics pillar should rise.",
         ],
         "source": {
             "title": "Unity Catalog metric views (docs)",
@@ -499,7 +499,7 @@ ACCELERATORS: list[dict] = [
             "Rank the recurring computations by traffic and inconsistency so you can prioritize which metric views to define first.",
             "Review the ranked drift report; pick the top KPIs to standardize via metric views.",
             "Define metric views for those KPIs (see the Author metric views guide) and point dashboards at them.",
-            "Re-run the readiness assessment — the Semantic Layer pillar should rise as KPIs consolidate.",
+            "Re-run the readiness assessment — the Metrics pillar should rise as KPIs consolidate.",
         ],
         "source": {
             "title": "Query history system table (docs)",
@@ -617,19 +617,19 @@ ACCELERATORS: list[dict] = [
     {
         "key": "domains-methodology-guide",
         "title": "Handbook: organize domains & stewardship",
-        "summary": "How to structure Genie Spaces and metric views around business domains, name metric views by convention, tag assets with their domain, and certify canonical assets with named stewards. Download the full handbook.",
+        "summary": "How to structure Genie Agents and metric views around business domains, name metric views by convention, tag assets with their domain, and certify canonical assets with named stewards. Download the full handbook.",
         "capability": "domains",
         "type": "guide",
         "effort": "Reference / self-guided",
         "what_it_does": (
-            "Organizing around business domains (not reports) keeps Genie Spaces focused and discoverable. "
-            "Metric views follow a naming convention ({subdomain}_{kpi_group}), and both spaces and metric views "
+            "Organizing around business domains (not reports) keeps Genie Agents focused and discoverable. "
+            "Metric views follow a naming convention ({subdomain}_{kpi_group}), and both agents and metric views "
             "are tagged with their domain for observability. Canonical assets are certified and assigned named stewards. "
             "This guide covers Phase 3 (Organize by domain) of the AI-ready-semantics handbook in depth, with the "
             "foundational discipline that makes a semantic layer sustainable."
         ),
         "prerequisites": [
-            "Genie Spaces and metric views already created per the build phases",
+            "Genie Agents and metric views already created per the build phases",
             "ASSIGN on governed tags to apply domain/steward classifications",
             "Business domain leads to confirm domain boundaries and steward assignments",
         ],
@@ -637,10 +637,10 @@ ACCELERATORS: list[dict] = [
         "target_level": 4,
         "review_mode": False,
         "steps": [
-            "Map your Genie Spaces to business domains and subdomains; one space per focused domain, under 30 items.",
+            "Map your Genie Agents to business domains and subdomains; one agent per focused domain, under 30 items.",
             "Name metric views by convention: {subdomain}_{kpi_group} to make ownership visible in the catalog.",
-            "Apply governed domain and steward tags to both Genie Spaces and metric views for discoverability and observability.",
-            "Identify the canonical (most-used, most-trusted) metric view or space per domain and certify it with a named steward.",
+            "Apply governed domain and steward tags to both Genie Agents and metric views for discoverability and observability.",
+            "Identify the canonical (most-used, most-trusted) metric view or agent per domain and certify it with a named steward.",
             "Download the handbook for the full domain-organization method and stewardship patterns.",
         ],
         "artifact_dir": "ai-ready-semantics",

--- a/app/server/content/library.py
+++ b/app/server/content/library.py
@@ -4,7 +4,7 @@ For each capability: a concise "what it is", technical + business value, clear
 recommendations, best practices, and PUBLIC Databricks documentation sources only.
 
 Product accuracy to preserve (without release-stage labels):
-  - Unity Catalog *Business Semantics* (metric views, glossary, domains,
+  - Unity Catalog *Business Semantics* (metric views, Pages, domains,
     synonyms, certification) is the customer-built, governed foundation.
   - *Genie Ontology* is the continuously-LEARNED enterprise context layer that
     Databricks builds on top of that foundation. The foundation FEEDS the
@@ -19,26 +19,26 @@ CAPABILITIES: dict[str, dict] = {
         "what": (
             "Genie Ontology is the business-aware context layer that lets Genie answer from "
             "your authoritative source. It brings together two kinds of context: the semantics "
-            "you MODEL and govern in Unity Catalog (metric views, domains, a business glossary, "
+            "you MODEL and govern in Unity Catalog (metric views, domains, Pages, "
             "synonyms, certified assets) and context Genie LEARNS from the assets you already "
-            "have (dashboards, saved queries, Genie Spaces, notebooks). It ranks every signal by "
+            "have (dashboards, saved queries, Genie Agents, notebooks). It ranks every signal by "
             "authority — things like certification, popularity, freshness, and ownership — so it "
             "answers from the source that is actually right. The modeled foundation FEEDS the "
             "learned layer, so preparing for Genie Ontology means maturing that foundation: "
-            "governance, metadata, metric views, domains, glossary, and curated Genie Spaces."
+            "governance, metadata, metric views, domains, Pages, and curated Genie Agents."
         ),
         "technical_value": "One governed meaning, reused across Genie, SQL, notebooks, dashboards, and BI — instead of definitions fragmented across tools.",
         "business_value": "Business users and AI agents give the same trustworthy answer to the same question. The foundation work pays off in AI/BI and Genie accuracy immediately.",
         "technical_enablement": [
-            "Mature the foundation first: UC governance, rich metadata, metric views, curated Genie Spaces.",
+            "Mature the foundation first: UC governance, rich metadata, metric views, curated Genie Agents.",
             "Engage your Databricks account team about Genie Ontology eligibility.",
         ],
         "business_adoption": [
             "Frame this as a semantic-standardization program, not a tool rollout.",
-            "Name owners for metrics, glossary terms, and domains before scaling.",
+            "Name owners for metrics, Pages, and domains before scaling.",
         ],
         "best_practices": [
-            "Treat 'preparing for Genie Ontology' as maturing UC Business Semantics + governance + Genie Spaces.",
+            "Treat 'preparing for Genie Ontology' as maturing UC Business Semantics + governance + Genie Agents.",
             "The foundation work improves AI/BI accuracy today — don't wait.",
         ],
         "sources": [
@@ -107,7 +107,7 @@ CAPABILITIES: dict[str, dict] = {
         "name": "Metadata Richness",
         "tagline": "The comments and tags Genie reads to understand your data.",
         "what": "Table and column comments, descriptions, and governed tags. Genie maps natural-language questions to the right tables and columns using this metadata, so its quality strongly predicts answer accuracy.",
-        "technical_value": "Higher first-attempt accuracy; less manual instruction-writing in each Genie Space.",
+        "technical_value": "Higher first-attempt accuracy; less manual instruction-writing in each Genie Agent.",
         "business_value": "Faster, more trustworthy self-serve answers and better discovery in Catalog Explorer.",
         "technical_enablement": [
             "Add COMMENT to every gold-layer table and column.",
@@ -153,7 +153,7 @@ CAPABILITIES: dict[str, dict] = {
         ],
     },
     "metric_views": {
-        "name": "Metric Views (Business Semantics)",
+        "name": "Metric Views",
         "tagline": "Centrally-defined, certified KPIs — the core of the semantic foundation.",
         "what": "Unity Catalog metric views define measures, dimensions, filters, and joins once, in governed YAML, and reuse them across Genie, dashboards, SQL, notebooks, and external BI. This is the central pillar of the semantic foundation that feeds Genie Ontology.",
         "technical_value": "One definition of each KPI consumed everywhere; no metric drift between BI and Genie.",
@@ -161,7 +161,7 @@ CAPABILITIES: dict[str, dict] = {
         "technical_enablement": [
             "Define metric views in YAML for your top KPIs (measures, dimensions, joins).",
             "Add synonyms, display names, and formatting for agent-friendliness.",
-            "Use the same metric views in dashboards and Genie Spaces.",
+            "Use the same metric views in dashboards and Genie Agents.",
         ],
         "business_adoption": [
             "Have business owners define the 'what' of each KPI, not just IT the 'how'.",
@@ -178,30 +178,30 @@ CAPABILITIES: dict[str, dict] = {
             {"title": "Redefining the semantics layer for BI and AI (blog)", "url": "https://www.databricks.com/blog/redefining-semantics-data-layer-future-bi-and-ai"},
         ],
     },
-    "genie_spaces": {
-        "name": "Genie Spaces",
+    "genie_agents": {
+        "name": "Genie Agents",
         "tagline": "Curated natural-language analytics over your governed data.",
-        "what": "A Genie Space is a curated room where business users ask questions in natural language. Curation — instructions, example/verified SQL, benchmark questions, and the tables/metric views in scope — is what makes answers accurate.",
+        "what": "A Genie Agent is a curated room where business users ask questions in natural language. Curation — instructions, example/verified SQL, benchmark questions, and the tables/metric views in scope — is what makes answers accurate.",
         "technical_value": "Scoped, governed context for the model; verified queries and benchmarks raise accuracy.",
         "business_value": "Self-serve answers for business users without writing SQL; faster decisions.",
         "technical_enablement": [
-            "Create a Genie Space scoped to a domain's gold tables and metric views.",
+            "Create a Genie Agent scoped to a domain's gold tables and metric views.",
             "Add instructions, example/verified SQL, and benchmark questions.",
             "Test answer quality and iterate on the instructions.",
         ],
         "business_adoption": [
             "Onboard real business users and capture their actual questions.",
             "Run a feedback loop to refine instructions and verified queries.",
-            "Scope spaces by business domain, not the whole catalog.",
+            "Scope agents by business domain, not the whole catalog.",
         ],
         "best_practices": [
-            "Prefer gold/semantic objects; give the space a tight, well-described scope.",
+            "Prefer gold/semantic objects; give the agent a tight, well-described scope.",
             "Maintain a benchmark question set to catch regressions as you tune.",
-            "Curate instructions/examples — an uncurated space answers poorly.",
+            "Curate instructions/examples — an uncurated agent answers poorly.",
         ],
         "sources": [
-            {"title": "Curate an effective Genie space (docs)", "url": "https://docs.databricks.com/aws/en/genie/best-practices"},
-            {"title": "Set up a Genie space (docs)", "url": "https://docs.databricks.com/aws/en/genie/set-up"},
+            {"title": "Curate an effective Genie agent (docs)", "url": "https://docs.databricks.com/aws/en/genie/best-practices"},
+            {"title": "Set up a Genie agent (docs)", "url": "https://docs.databricks.com/aws/en/genie/set-up"},
         ],
     },
     "domains": {
@@ -305,7 +305,7 @@ CAPABILITIES: dict[str, dict] = {
 # Display order for the Learn tab.
 CAPABILITY_ORDER = [
     "ontology", "unity_catalog", "metadata", "relationships",
-    "metric_views", "genie_spaces", "domains", "adoption",
+    "metric_views", "genie_agents", "domains", "adoption",
 ]
 
 

--- a/app/server/content/methodology.py
+++ b/app/server/content/methodology.py
@@ -2,7 +2,7 @@
 
 Where `library.py` explains *what* each pillar is and `accelerators.py` gives
 the customer something *runnable*, this module encodes the *method*: the
-phased, iterative process for curating metric views, Genie Spaces, and the
+phased, iterative process for curating metric views, Genie Agents, and the
 governed tags/domains that make them discoverable — so an AI agent can answer
 accurately and consistently.
 
@@ -55,12 +55,12 @@ PHASES: list[dict] = [
     {
         "key": "organize",
         "name": "Organize by domain",
-        "goal": "Structure Genie Spaces and metric views around the business, not around reports.",
+        "goal": "Structure Genie Agents and metric views around the business, not around reports.",
         "steps": [
-            "Model a Genie Space as a business domain/subdomain (e.g. 'Online Marketing'); model a metric view as a KPI group within it (e.g. 'Conversion Metrics').",
+            "Model a Genie Agent as a business domain/subdomain (e.g. 'Online Marketing'); model a metric view as a KPI group within it (e.g. 'Conversion Metrics').",
             "Name metric views by convention — {subdomain}_{kpi_group} — so they sort and read predictably.",
-            "Tag Genie Spaces and metric views with their domain/subdomain for discoverability and observability. Optionally mirror the structure as one Unity Catalog schema per domain.",
-            "Keep each space focused — a Genie Space supports up to 30 tables/views/metric views, and tighter domains answer better. If you approach the limit, split into more granular subdomain spaces.",
+            "Tag Genie Agents and metric views with their domain/subdomain for discoverability and observability. Optionally mirror the structure as one Unity Catalog schema per domain.",
+            "Keep each agent focused — a Genie Agent supports up to 30 tables/views/metric views, and tighter domains answer better. If you approach the limit, split into more granular subdomain agents.",
         ],
     },
     {
@@ -68,11 +68,11 @@ PHASES: list[dict] = [
         "name": "Test incrementally",
         "goal": "Onboard one measure at a time, prove it, and capture what worked as reusable examples and benchmarks.",
         "steps": [
-            "Add one measure to the space, ask sample questions, and validate the answer before adding the next measure.",
-            "Save each validated query as an example SQL query in the space so the agent reuses it. Keep example SQL simple (prefer WHERE over CASE) — complexity adds reasoning load.",
+            "Add one measure to the agent, ask sample questions, and validate the answer before adding the next measure.",
+            "Save each validated query as an example SQL query in the agent so it reuses it. Keep example SQL simple (prefer WHERE over CASE) — complexity adds reasoning load.",
             "Leave prompt matching enabled on columns so the agent maps user language to real values and tolerates misspellings; for ambiguous categorical values, add exact-match filter instructions.",
-            "Always give the Space itself a name AND a description — multi-agent/multi-space routing depends on the description to delegate the question correctly.",
-            "Write space instructions as: (1) trigger condition — when the user asks about X, (2) required action — always do Y, (3) an example question and expected behavior.",
+            "Always give the Agent itself a name AND a description — multi-agent/multi-agent routing depends on the description to delegate the question correctly.",
+            "Write agent instructions as: (1) trigger condition — when the user asks about X, (2) required action — always do Y, (3) an example question and expected behavior.",
             "Build benchmarks: for each validated measure, add two to four phrasings of the same question with ground-truth SQL; add more phrasings for questions likely to be misread.",
         ],
     },
@@ -82,8 +82,8 @@ PHASES: list[dict] = [
         "goal": "Regression-test every change, then pilot with real business users and loop their feedback back in.",
         "steps": [
             "Re-run all benchmarks after every change (new measure, new instruction). If a previously passing benchmark now fails, the latest addition is the likely cause.",
-            "Regression testing is per space; if you connect multiple spaces (a supervisor/multi-agent setup), also test the cross-space interactions.",
-            "Share the curated space with pilot business users; have them use the built-in feedback and keep conversations reviewable by space managers so curators can see and act on responses.",
+            "Regression testing is per agent; if you connect multiple agents (a supervisor/multi-agent setup), also test the cross-agent interactions.",
+            "Share the curated agent with pilot business users; have them use the built-in feedback and keep conversations reviewable by agent managers so curators can see and act on responses.",
             "Feed both regression failures and user feedback back into the testing phase — this is a loop, not a one-time release.",
         ],
     },
@@ -100,19 +100,19 @@ PRACTICES: dict[str, list[str]] = {
         "Comment at all three levels (view, dimension, measure) and add synonyms + format specification — the agent reasons over every level.",
         "Use MEASURE() for composability so a measure can build on other measures/dimensions in the same view.",
         "For multi-fact or nested KPIs, build a base view (CTEs) first, then the metric view on top — the metric view pre-defines aggregation and cuts hallucination risk.",
-        "Once a metric view sits on top of a base view, remove the raw base view/tables from the Genie Space — expose only the metric view to avoid redundancy and ambiguity.",
+        "Once a metric view sits on top of a base view, remove the raw base view/tables from the Genie Agent — expose only the metric view to avoid redundancy and ambiguity.",
     ],
-    "genie_spaces": [
-        "Scope a space to one business domain/subdomain and keep it under the 30-item limit; split when it grows.",
-        "Always add a space description — routing across spaces depends on it.",
+    "genie_agents": [
+        "Scope an agent to one business domain/subdomain and keep it under the 30-item limit; split when it grows.",
+        "Always add an agent description — routing across agents depends on it.",
         "Save validated queries as example SQL and keep them simple.",
         "Structure instructions as trigger condition → required action → example.",
         "Enable prompt matching; add exact-match instructions for ambiguous categorical values.",
         "Benchmark with two to four phrasings per question and ground-truth SQL; regression-test after every change.",
     ],
     "domains": [
-        "Genie Space = domain/subdomain; metric view = KPI group within it.",
-        "Name metric views {subdomain}_{kpi_group}; tag spaces and metric views with their domain for discoverability and observability.",
+        "Genie Agent = domain/subdomain; metric view = KPI group within it.",
+        "Name metric views {subdomain}_{kpi_group}; tag agents and metric views with their domain for discoverability and observability.",
         "Assign a named owner/steward per domain and certify the canonical assets so the agent (and users) know what to trust.",
     ],
 }
@@ -144,8 +144,8 @@ def methodology_prompt() -> str:
     lines.append(
         "Non-negotiable techniques: one source per metric view; validate one measure at a time against the trusted number; "
         "comment at view/dimension/measure level and add synonyms; build a base view (CTEs) first for multi-fact/nested KPIs, then the metric view on top; "
-        "one Genie Space per domain (<=30 items) with a description; save validated queries as example SQL and keep it simple; "
-        "structure space instructions as trigger->action->example; benchmark 2-4 phrasings per question with ground-truth SQL and regression-test after every change; "
-        "name metric views {subdomain}_{kpi_group} and tag spaces/metric views with their domain; certify canonical assets and name a steward per domain."
+        "one Genie Agent per domain (<=30 items) with a description; save validated queries as example SQL and keep it simple; "
+        "structure agent instructions as trigger->action->example; benchmark 2-4 phrasings per question with ground-truth SQL and regression-test after every change; "
+        "name metric views {subdomain}_{kpi_group} and tag agents/metric views with their domain; certify canonical assets and name a steward per domain."
     )
     return "\n".join(lines)

--- a/app/server/pillars.py
+++ b/app/server/pillars.py
@@ -34,12 +34,12 @@ READINESS_STAGES = [
     {
         "min_score": 55,
         "label": "Ready for Session 2 — Genie Room Setup & Tuning",
-        "detail": "Metadata and a semantic layer exist; stand up and tune Genie Spaces.",
+        "detail": "Metadata and a semantic layer exist; stand up and tune Genie Agents.",
     },
     {
         "min_score": 72,
         "label": "Ready for Session 3 — Validation & Business Onboarding",
-        "detail": "Genie Spaces are curated; validate accuracy and onboard business users.",
+        "detail": "Genie Agents are curated; validate accuracy and onboard business users.",
     },
     {
         "min_score": 85,
@@ -72,18 +72,18 @@ PILLARS = [
         "capability": "relationships",
     },
     {
-        "key": "semantic_layer",
-        "name": "Semantic Layer (Business Semantics)",
+        "key": "metrics",
+        "name": "Metrics",
         "weight": 20,
-        "short": "Metric views, glossary, synonyms — the foundation that feeds the ontology.",
+        "short": "Metric views — the governed metrics foundation that feeds the ontology.",
         "capability": "metric_views",
     },
     {
-        "key": "genie_spaces",
-        "name": "Genie Spaces",
+        "key": "genie_agents",
+        "name": "Genie Agents",
         "weight": 16,
-        "short": "Curated Genie Spaces with instructions, example SQL, and benchmarks.",
-        "capability": "genie_spaces",
+        "short": "Curated Genie Agents with instructions, example SQL, and benchmarks.",
+        "capability": "genie_agents",
     },
     {
         "key": "domains",

--- a/app/server/routes/genie.py
+++ b/app/server/routes/genie.py
@@ -1,4 +1,4 @@
-"""Genie endpoints — optionally test answer quality against a configured Genie Space.
+"""Genie endpoints — optionally test answer quality against a configured Genie Agent.
 
 Set GENIE_SPACE_ID to enable. Used in pillar 5 to demonstrate live value.
 """
@@ -27,8 +27,8 @@ class GenieMessageRequest(BaseModel):
 
 
 @router.get("/genie/spaces")
-async def list_genie_spaces():
-    """List Genie Spaces visible to the app (for the pillar 5 detail view)."""
+async def list_genie_agents():
+    """List Genie Agents visible to the app (for the pillar 5 detail view)."""
     host = get_workspace_host()
     headers = get_auth_headers()
     if not host or not headers:
@@ -42,7 +42,7 @@ async def list_genie_spaces():
                 raw = data.get("spaces", []) or data.get("data", []) or []
                 return {"spaces": [{"id": s.get("space_id") or s.get("id"), "title": s.get("title") or s.get("name")} for s in raw]}
     except Exception as e:
-        logger.warning(f"list_genie_spaces failed: {e}")
+        logger.warning(f"list_genie_agents failed: {e}")
         return {"spaces": [], "note": str(e)[:120]}
 
 

--- a/app/server/routes/plan.py
+++ b/app/server/routes/plan.py
@@ -40,8 +40,8 @@ class PlanPdfRequest(BaseModel):
 
 
 _GROUND_TRUTH = """PRODUCT GROUND TRUTH (do not violate):
-- Genie Ontology is a LEARNED enterprise context layer built on top of the customer's governed Unity Catalog Business Semantics (metric views, glossary, domains, synonyms). The foundation FEEDS the ontology. Never describe the learned ontology layer as generally available.
-- "Preparing for Genie Ontology" = maturing UC governance, metadata, metric views/semantics, Genie Spaces, and domains."""
+- Genie Ontology is a LEARNED enterprise context layer built on top of the customer's governed Unity Catalog Business Semantics (metric views, Pages, domains, synonyms). The foundation FEEDS the ontology. Never describe the learned ontology layer as generally available.
+- "Preparing for Genie Ontology" = maturing UC governance, metadata, metric views/semantics, Genie Agents, and domains."""
 
 
 def _scorecard_digest(sc: Optional[dict]) -> str:
@@ -91,7 +91,7 @@ PUBLIC DATABRICKS ACCELERATORS you may recommend (only these; each is a real, Da
 Keep it tight and scannable — no filler, no generic multi-phase project plan. Produce exactly these sections:
 1. **Where you are** — 2-3 sentences on their readiness, tied to their overall score/stage and their biggest levers (the lowest-scoring, highest-weight pillars).
 2. **Top recommendations** — the 4-6 highest-impact actions, prioritized worst-gap first. Each bullet must: (a) name the specific pillar/gap it closes, (b) give the concrete technical step AND the business/ownership step, and (c) where one applies, name the relevant accelerator above with its link.
-3. **Suggested sequence** — a NUMBERED list of clear, tactical steps the customer can follow in order (what to do first → next). Each step is a concrete action (e.g. "Declare PK/FK constraints on your 8 gold fact tables"), not a theme. Where the work involves building metric views, Genie Spaces, or domain tags, follow the BUILD METHODOLOGY above — reflect its phases and non-negotiable techniques (one source per metric view, validate one measure at a time, base views for multi-fact KPIs, one focused Genie Space per domain, benchmark + regression-test). Make these specific enough to hand to a data team.
+3. **Suggested sequence** — a NUMBERED list of clear, tactical steps the customer can follow in order (what to do first → next). Each step is a concrete action (e.g. "Declare PK/FK constraints on your 8 gold fact tables"), not a theme. Where the work involves building metric views, Genie Agents, or domain tags, follow the BUILD METHODOLOGY above — reflect its phases and non-negotiable techniques (one source per metric view, validate one measure at a time, base views for multi-fact KPIs, one focused Genie Agent per domain, benchmark + regression-test). Make these specific enough to hand to a data team.
 4. **Example Genie use cases** — 2-3 realistic questions Genie could answer once the foundation is in place, each one line (the question + the metric views / tables it would use). Infer the domain from the catalog/schema names in the assessment signals if available; otherwise keep them broadly applicable and say so in a short lead-in line.
 
 Do not invent scores or accelerators that are not listed above. Be specific to the assessment numbers."""

--- a/databricks.yml
+++ b/databricks.yml
@@ -23,7 +23,7 @@ variables:
     description: "Optional comma-separated catalogs to assess (empty = all non-system catalogs the app SP can see)"
     default: ""
   genie_space_id:
-    description: "Optional Genie Space ID to enable the live answer-quality test (pillar 5)"
+    description: "Optional Genie Agent ID to enable the live answer-quality test (pillar 5)"
     default: ""
   lakebase_instance_name:
     description: "Lakebase instance that hosts this app's per-user history DB (the app gets its own database on it). Only needed when USE_LAKEBASE=true. Leave empty to let post_deploy.py skip history persistence; set to an existing instance name to reuse it."

--- a/docs/accelerators-plan.md
+++ b/docs/accelerators-plan.md
@@ -106,15 +106,15 @@ assessment → Metadata pillar score goes up → overall readiness stage advance
 - **Pre-joined gold view scaffolder** (build) — generate wide/star views for the
   common join paths Genie should see.
 
-### Semantic Layer / Metric Views (weight 22)
+### Metrics / Metric Views (weight 18)
 - **Metric-view scaffolder** (build) — from a KPI inventory sheet (or from query
   history) generate metric-view YAML stubs (measures/dimensions/joins/synonyms).
 - **KPI-drift finder** (build) — mine query history for the same KPI computed
   differently across dashboards → prioritize which metric views to define first.
 
-### Genie Spaces (weight 16)
-- **Genie Space bootstrapper** (build, leverages `genie-rooms` skill) — create a
-  space scoped to a domain's gold tables + metric views, seed instructions from
+### Genie Agents (weight 16)
+- **Genie Agent bootstrapper** (build, leverages `genie-rooms` skill) — create an
+  agent scoped to a domain's gold tables + metric views, seed instructions from
   metadata.
 - **Benchmark harness** (build, extends `genie_client.py`) — run a benchmark
   question set via the Conversation API, score answers, track regressions.

--- a/docs/building-ai-ready-semantics.md
+++ b/docs/building-ai-ready-semantics.md
@@ -1,11 +1,11 @@
 # Building AI-Ready Business Semantics
 
-A practical, self-guided method for curating **metric views**, **Genie Spaces**, and
+A practical, self-guided method for curating **metric views**, **Genie Agents**, and
 the **governed tags/domains** that make them discoverable — so an AI agent answers
 your business questions accurately and consistently.
 
 Trustworthy talk-to-data rests on a unified, curated semantic foundation. Metric
-views and Genie Spaces are the tools for building it, but they only pay off with
+views and Genie Agents are the tools for building it, but they only pay off with
 deliberate curation: the integrity of the numbers, the richness of the metadata,
 and the discipline of testing are what separate a demo from something a business
 team relies on.
@@ -30,7 +30,7 @@ roadmaps. Both describe the same five-phase process; edit them together.
 
 - The fact and dimension tables behind each KPI, governed in Unity Catalog.
 - Source documentation and the data model (tables and their relationships).
-- Permission to create metric views and Genie Spaces.
+- Permission to create metric views and Genie Agents.
 - If you are migrating an existing BI semantic model: the measure definitions and
   the reports that consume them, so nothing is silently dropped.
 
@@ -45,9 +45,9 @@ a loop you stay in as the semantic layer grows.
 |---|---|
 | 1. Prepare | A scoped KPI list mapped to its Unity Catalog sources of truth. |
 | 2. Build the semantic layer | Governed metric views — one fact source each — with rich metadata. |
-| 3. Organize by domain | Genie Spaces and metric views structured around the business. |
+| 3. Organize by domain | Genie Agents and metric views structured around the business. |
 | 4. Test incrementally | Validated measures, saved example SQL, and question benchmarks. |
-| 5. Validate & release | Regression-tested spaces, piloted with real users, feedback looping back. |
+| 5. Validate & release | Regression-tested agents, piloted with real users, feedback looping back. |
 
 ---
 
@@ -82,7 +82,7 @@ spans multiple fact tables or contains nested logic, build a **base view** first
 > unaggregated, row-level data, so the agent still has to infer the aggregation and
 > may get it wrong. A metric view **pre-defines** the aggregation, which cuts
 > hallucination risk. Once the metric view exists, **remove the raw base view and
-> tables from the Genie Space** and expose only the metric view — keeping both
+> tables from the Genie Agent** and expose only the metric view — keeping both
 > creates redundancy and ambiguity.
 
 ### Building it up
@@ -124,18 +124,18 @@ spans multiple fact tables or contains nested logic, build a **base view** first
 
 ## Phase 3 — Organize by domain, not by report
 
-**Goal: structure Genie Spaces and metric views around the business.**
+**Goal: structure Genie Agents and metric views around the business.**
 
-- **Genie Space = a business domain or subdomain** (for example, "Online
+- **Genie Agent = a business domain or subdomain** (for example, "Online
   Marketing"). **Metric view = a KPI group** within it (for example, "Conversion
   Metrics").
 - Name metric views by convention: `{subdomain}_{kpi_group}`.
-- **Tag** Genie Spaces and metric views with their domain/subdomain for
+- **Tag** Genie Agents and metric views with their domain/subdomain for
   discoverability and observability. Optionally mirror the structure in Unity
   Catalog — one schema per domain or subdomain.
-- Keep each space focused. A Genie Space supports up to **30** tables/views/metric
+- Keep each agent focused. A Genie Agent supports up to **30** tables/views/metric
   views, and the tighter the domain, the better the agent performs. As you approach
-  the limit, split the domain into more granular subdomain spaces.
+  the limit, split the domain into more granular subdomain agents.
 
 ---
 
@@ -143,18 +143,18 @@ spans multiple fact tables or contains nested logic, build a **base view** first
 
 **Goal: onboard one measure at a time, prove it, and capture what works.**
 
-- Add **one measure** to the space, ask sample questions, and validate the answer
+- Add **one measure** to the agent, ask sample questions, and validate the answer
   before adding the next.
-- Save each validated query as an **example SQL query** in the space so the agent
+- Save each validated query as an **example SQL query** in the agent so it
   reuses it or learns from it. Keep example SQL **simple** — prefer `WHERE` over
   `CASE`; complexity adds to the agent's reasoning load.
 - Leave **prompt matching** enabled on columns so the agent maps user language to
   real values and tolerates misspellings. For ambiguous categorical values, add
   exact-match filter instructions.
-- Always give the **space itself a name and a description**. Routing across multiple
-  spaces (and multi-agent setups) depends on the description to delegate a question
-  to the right space — without one, an orchestrating agent cannot reliably choose.
-- Structure space instructions as: **(1) trigger condition** — when the user asks
+- Always give the **agent itself a name and a description**. Routing across multiple
+  agents (and multi-agent setups) depends on the description to delegate a question
+  to the right agent — without one, an orchestrating agent cannot reliably choose.
+- Structure agent instructions as: **(1) trigger condition** — when the user asks
   about X; **(2) required action** — then always do Y; **(3) example** — a sample
   question and the expected behavior.
 
@@ -174,12 +174,12 @@ or easy to misread. Repeat for each KPI until the whole KPI group is covered.
 - **Re-run all benchmarks after every change** — a new measure, a new instruction.
   If a previously passing benchmark now fails, the latest addition is the likely
   cause. Use the failure analysis and fix-review tools to diagnose it.
-- Regression testing is **per space** — adding a new space does not affect existing
-  ones. If you connect multiple spaces (a supervisor or custom multi-agent system),
-  also test the **cross-space** interactions.
-- **Pilot with business users.** Share the curated space, and have testers use the
+- Regression testing is **per agent** — adding a new agent does not affect existing
+  ones. If you connect multiple agents (a supervisor or custom multi-agent system),
+  also test the **cross-agent** interactions.
+- **Pilot with business users.** Share the curated agent, and have testers use the
   built-in feedback to flag and comment on responses. Keep conversations
-  **reviewable by space managers** so curators can see the feedback — a private
+  **reviewable by agent managers** so curators can see the feedback — a private
   conversation hides the response from the curator.
 - Feed **both** regression failures and user feedback back into Phase 4. This is a
   loop, not a one-time release.
@@ -203,11 +203,11 @@ Always review generated output before you apply it.
   then the metric view on top.
 - **Validate one measure at a time** against the trusted number.
 - **Comment at view/dimension/measure level**; add **synonyms** and **format specs**.
-- **One Genie Space per domain**, under 30 items, **with a description**.
+- **One Genie Agent per domain**, under 30 items, **with a description**.
 - **Save validated queries as example SQL** and keep it simple.
 - **Instructions:** trigger → action → example.
 - **Benchmark** 2–4 phrasings per question with ground-truth SQL; **regression-test
   after every change**.
-- **Name** metric views `{subdomain}_{kpi_group}`; **tag** spaces and metric views
+- **Name** metric views `{subdomain}_{kpi_group}`; **tag** agents and metric views
   with their domain.
 - **Certify** canonical assets and **name a steward** per domain.


### PR DESCRIPTION
## Summary
Aligns the app with current Genie product naming. **No pillar or scoring changes** — still 7 pillars at their original weights; this is a pure rename.

- **Genie Spaces → Genie Agents** across the pillar, embedded content, methodology, UI, and docs. Databricks API contracts are preserved unchanged: `GENIE_SPACE_ID`, `/api/2.0/genie/spaces`, and the `system.access.audit` `space_id` column.
- **Semantic Layer pillar → Metrics** (`key` `semantic_layer` → `metrics`), scoped to metric views; the subline now references only metric views.
- **Business-Semantics "Glossary" references → Pages**. Generic "glossary-grounded" references in the metadata-comments accelerator (a customer's own glossary/standards) are intentionally left as-is.

## Validation
- Python: 7 pillars, weights sum to 100; every pillar resolves probe + capability + best-practices + methodology; no `pages`/`score_exempt` anywhere.
- Frontend: `tsc --noEmit` clean, 16/16 vitest, production build green.

Stacked below the new **Pages pillar** PR, which builds on this rename.

This pull request and its description were written by Isaac.
