### PR TITLE
Add Pages & Business Concepts readiness pillar (Beta)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ app/
     genie_client.py          — Genie Conversation API (answer-quality test)
     lakebase_client.py       — optional snapshot persistence pool
     snapshots.py             — optional assessment history (Lakebase)
-    pillars.py               — canonical 7 readiness pillars + maturity model
+    pillars.py               — canonical 8 readiness pillars + maturity model
     assessment/
       probes.py              — read-only SQL/REST probes (graceful degradation)
       scoring.py             — combine technical + self-assessment → scorecard
@@ -146,7 +146,7 @@ databricks.yml               — DABs: app + sql-warehouse resource
 ## Readiness pillars (each scored 0-4)
 
 Unity Catalog Foundation · Metadata Richness · Relationships & Modeling ·
-Metrics · Genie Agents · Domains & Stewardship ·
+Metrics · Genie Agents · Domains & Stewardship · Pages & Business Concepts ·
 Adoption & Activity. The overall score maps to a **Genie Foundations** session
 ("Ready for Session 2 — Genie Room Setup", etc.).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy it into a workspace and it will:
 
 - **Assess** the live environment and score maturity across the readiness pillars
   Genie Ontology depends on (Unity Catalog, metadata, relationships, metrics /
-  metric views, Genie Agents, domains, adoption).
+  metric views, Genie Agents, domains, Pages, adoption).
 - **Explain** each capability from a **technical** and a **business** standpoint, with
   accurate GA / preview status.
 - **Recommend** best practices for both technical enablement and business adoption.
@@ -22,9 +22,9 @@ The assessment is **read-only** and degrades gracefully when a signal isn't avai
 
 The app has three tabs. Each walkthrough below is a short, sped-up screen capture.
 
-### Assess — the 7-pillar readiness scorecard
+### Assess — the 8-pillar readiness scorecard
 
-Run a read-only assessment that scores your workspace across seven pillars, rolls up to a
+Run a read-only assessment that scores your workspace across eight pillars, rolls up to a
 0–100 readiness score and maturity stage, and expands each pillar to its signals and gaps.
 
 ![Assess tab walkthrough: running the readiness assessment, viewing the overall score and pillar-maturity radar, and expanding a pillar to see its signals and gaps.](assets/assess-cuj.gif)

--- a/app/frontend/__tests__/accelerators.test.tsx
+++ b/app/frontend/__tests__/accelerators.test.tsx
@@ -18,7 +18,10 @@ import type { Accelerator, AcceleratorType } from '../src/types';
 // Fully hermetic: no live network, no running backend, no jsdom — the component
 // is rendered to static HTML via react-dom/server.
 
-// The 7 capability keys the app scores. Each MUST have >=1 accelerator.
+// The scored capability keys — each MUST have >=1 accelerator. The Beta "pages"
+// pillar is score_exempt (shown/explained but not scored) and ships with Learn
+// guidance but no runnable accelerator yet, so it is intentionally excluded from
+// this accelerator-coverage invariant.
 const CAPABILITY_KEYS = [
   'unity_catalog',
   'metadata',

--- a/app/frontend/src/components/HelpButton.tsx
+++ b/app/frontend/src/components/HelpButton.tsx
@@ -76,7 +76,7 @@ export default function HelpButton({ config }: { config: AppConfig }) {
               </h3>
               <p className="text-sm text-ink-700 leading-relaxed">
                 {config.app_name} assesses your Databricks workspace&apos;s maturity for Genie
-                Ontology across seven readiness pillars, explains each capability, and generates a
+                Ontology across eight readiness pillars, explains each capability, and generates a
                 tailored, prioritized action plan. The assessment is read-only.
               </p>
             </div>

--- a/app/frontend/src/components/Scorecard.tsx
+++ b/app/frontend/src/components/Scorecard.tsx
@@ -147,13 +147,16 @@ export default function Scorecard({
         .filter((p) => {
           const ps = pillarsByKey[p.key];
           // Always drop score-exempt pillars (e.g. the Beta Pages placeholder) —
-          // they carry no real score and would show as a misleading 0.
-          if (ps?.score_exempt) return false;
-          // While streaming, keep every config pillar so the radar draws a full
-          // polygon filling from 0 (Recharts collapses to a dot/line with <3
-          // points). On a finalized scorecard, drop pillars absent from it (e.g. an
-          // old snapshot saved before a pillar existed) so they don't plot a false
-          // 0 spoke.
+          // they carry no real score and would show as a misleading 0. Prefer the
+          // config flag so it's excluded from the first render, before its stream
+          // event arrives (otherwise the radar briefly plots it at 0 and the spoke
+          // count jumps when the event lands); fall back to the streamed value.
+          if (p.score_exempt || ps?.score_exempt) return false;
+          // While streaming, keep every (non-exempt) config pillar so the radar
+          // draws a full polygon filling from 0 (Recharts collapses to a dot/line
+          // with <3 points). On a finalized scorecard, drop pillars absent from it
+          // (e.g. an old snapshot saved before a pillar existed) so they don't plot
+          // a false 0 spoke.
           if (phase === 'running') return true;
           return !!ps;
         })
@@ -163,7 +166,10 @@ export default function Scorecard({
           pillar: p.name,
           score: Math.round(pillarsByKey[p.key]?.score ?? 0),
         })),
-    [config.pillars, pillarsByKey]
+    // `phase` is read in the filter (running vs finalized), so it must be a dep —
+    // otherwise an errored stream that flips phase→done without changing
+    // pillarsByKey wouldn't re-filter, leaving false 0 spokes plotted.
+    [config.pillars, pillarsByKey, phase]
   );
 
   const trendData = useMemo(
@@ -204,6 +210,12 @@ export default function Scorecard({
           completed = true;
           setOverall(ev.overall);
           setTopGaps(ev.top_gaps);
+          // Reconcile pillarsByKey from the authoritative final list, not just the
+          // discrete 'pillar' events — so any pillar present in the completed run
+          // is never misrendered as "Not in this assessment", and the radar memo
+          // recomputes on completion.
+          for (const p of ev.pillars) collected[p.key] = p;
+          setPillarsByKey({ ...collected });
           setScorecard({ overall: ev.overall, pillars: ev.pillars, top_gaps: ev.top_gaps });
           setPhase('done');
           if (ev.snapshot_id != null) setCurrentId(ev.snapshot_id);

--- a/app/frontend/src/components/Scorecard.tsx
+++ b/app/frontend/src/components/Scorecard.tsx
@@ -70,7 +70,7 @@ function fmtWhen(iso: string): string {
 }
 
 // Wrap a pillar name to <=~16-char lines so long titles like
-// "Relationships & Modeling" don't clip off the radar chart.
+// "Domains & Stewardship" don't clip off the radar chart.
 function wrapLabel(text: string, maxChars = 16): string[] {
   const words = text.split(' ');
   const lines: string[] = [];
@@ -143,12 +143,16 @@ export default function Scorecard({
 
   const radarData = useMemo(
     () =>
-      config.pillars.map((p) => ({
-        // Use the pillar's card title (name), not its long description, so the
-        // radar labels match the 7 pillar cards below.
-        pillar: p.name,
-        score: Math.round(pillarsByKey[p.key]?.score ?? 0),
-      })),
+      config.pillars
+        // Drop score-exempt pillars (e.g. the Beta Pages placeholder) — they
+        // carry no real score and would show as a misleading 0 on the radar.
+        .filter((p) => !pillarsByKey[p.key]?.score_exempt)
+        .map((p) => ({
+          // Use the pillar's card title (name), not its long description, so the
+          // radar labels match the scored pillar cards below.
+          pillar: p.name,
+          score: Math.round(pillarsByKey[p.key]?.score ?? 0),
+        })),
     [config.pillars, pillarsByKey]
   );
 
@@ -294,7 +298,7 @@ export default function Scorecard({
         <h2 className="text-xl font-bold text-ink-900">Assess your Genie Ontology readiness</h2>
         <p className="text-sm text-ink-600 mt-2 leading-relaxed">
           This reads your Unity Catalog metadata (catalogs, comments, constraints, metric views,
-          Genie Agents, tags) to score your readiness across seven pillars. It runs read-only as the
+          Genie Agents, tags) to score your readiness across eight pillars. It runs read-only as the
           app's service principal and typically takes 30–60 seconds.
         </p>
       </div>
@@ -487,29 +491,44 @@ export default function Scorecard({
           }
           const open = expanded === p.key;
           const s = levelStyle(p.level);
+          const exempt = p.score_exempt;
           return (
-            <div key={p.key} className={`card overflow-hidden ${!p.available ? 'opacity-80' : ''}`}>
+            <div key={p.key} className={`card overflow-hidden ${!p.available && !exempt ? 'opacity-80' : ''}`}>
               <button
                 onClick={() => setExpanded(open ? null : p.key)}
                 className="w-full flex items-center gap-4 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
               >
                 <div className="w-12 text-center shrink-0">
-                  <div className="text-lg font-bold tabular-nums" style={{ color: scoreColor(p.score) }}>
-                    {Math.round(p.score)}
-                  </div>
+                  {exempt ? (
+                    <div className="text-lg font-bold text-ink-300">—</div>
+                  ) : (
+                    <div className="text-lg font-bold tabular-nums" style={{ color: scoreColor(p.score) }}>
+                      {Math.round(p.score)}
+                    </div>
+                  )}
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="font-semibold text-ink-900">{p.name}</span>
-                    <LevelBadge level={p.level} label={p.level_label} />
-                    {!p.available && <span className="text-[11px] text-ink-400 italic">not available</span>}
+                    {exempt ? (
+                      <span className="text-[11px] font-medium px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200">
+                        Beta · not scored
+                      </span>
+                    ) : (
+                      <>
+                        <LevelBadge level={p.level} label={p.level_label} />
+                        {!p.available && <span className="text-[11px] text-ink-400 italic">not available</span>}
+                      </>
+                    )}
                   </div>
                   <p className="text-xs text-ink-500 mt-0.5 truncate">{p.short}</p>
                 </div>
                 <div className="hidden sm:block w-24 shrink-0">
-                  <div className="h-1.5 rounded-full bg-gray-100 overflow-hidden">
-                    <div className="h-full rounded-full" style={{ width: `${p.score}%`, backgroundColor: s.hex }} />
-                  </div>
+                  {!exempt && (
+                    <div className="h-1.5 rounded-full bg-gray-100 overflow-hidden">
+                      <div className="h-full rounded-full" style={{ width: `${p.score}%`, backgroundColor: s.hex }} />
+                    </div>
+                  )}
                 </div>
                 <ChevronDown size={18} className={`shrink-0 text-ink-400 transition-transform ${open ? 'rotate-180' : ''}`} />
               </button>

--- a/app/frontend/src/components/Scorecard.tsx
+++ b/app/frontend/src/components/Scorecard.tsx
@@ -144,11 +144,19 @@ export default function Scorecard({
   const radarData = useMemo(
     () =>
       config.pillars
-        // Only plot pillars actually present in this scorecard, and drop
-        // score-exempt ones (e.g. the Beta Pages placeholder). This also guards a
-        // snapshot saved before a pillar existed (old run loaded after an upgrade):
-        // without the presence check it would plot a misleading 0 spoke.
-        .filter((p) => pillarsByKey[p.key] && !pillarsByKey[p.key]?.score_exempt)
+        .filter((p) => {
+          const ps = pillarsByKey[p.key];
+          // Always drop score-exempt pillars (e.g. the Beta Pages placeholder) —
+          // they carry no real score and would show as a misleading 0.
+          if (ps?.score_exempt) return false;
+          // While streaming, keep every config pillar so the radar draws a full
+          // polygon filling from 0 (Recharts collapses to a dot/line with <3
+          // points). On a finalized scorecard, drop pillars absent from it (e.g. an
+          // old snapshot saved before a pillar existed) so they don't plot a false
+          // 0 spoke.
+          if (phase === 'running') return true;
+          return !!ps;
+        })
         .map((p) => ({
           // Use the pillar's card title (name), not its long description, so the
           // radar labels match the scored pillar cards below.
@@ -481,12 +489,16 @@ export default function Scorecard({
         {config.pillars.map((cp) => {
           const p = pillarsByKey[cp.key];
           if (!p) {
-            // Still streaming → show the loading skeleton. But on a completed
-            // scorecard a missing pillar means this snapshot predates it (e.g. an
-            // old run saved before Pages existed, loaded after an upgrade): there's
-            // nothing to wait for, so show a muted "not in this assessment" instead
-            // of a spinner that never resolves.
+            // Three states for a pillar with no result yet:
+            //  - streaming (phase running): still expected → spinner + "Checking…"
+            //  - finalized scorecard (completed run or loaded snapshot, so `overall`
+            //    is set): genuinely absent — e.g. an old snapshot saved before this
+            //    pillar existed → "Not in this assessment"
+            //  - otherwise (stream errored/ended before completing): it was expected
+            //    but didn't load; don't claim it's absent → "Not loaded"
             const waiting = phase === 'running';
+            const finalized = phase === 'done' && !!overall;
+            const label = waiting ? 'Checking…' : finalized ? 'Not in this assessment' : 'Not loaded';
             return (
               <div key={cp.key} className="card flex items-center gap-4 px-4 py-3 opacity-70">
                 {waiting ? (
@@ -496,9 +508,7 @@ export default function Scorecard({
                 )}
                 <div className="flex-1 min-w-0">
                   <span className="font-semibold text-ink-500">{cp.name}</span>
-                  <p className="text-xs text-ink-400 mt-0.5 truncate">
-                    {waiting ? 'Checking…' : 'Not in this assessment'}
-                  </p>
+                  <p className="text-xs text-ink-400 mt-0.5 truncate">{label}</p>
                 </div>
               </div>
             );

--- a/app/frontend/src/components/Scorecard.tsx
+++ b/app/frontend/src/components/Scorecard.tsx
@@ -70,7 +70,7 @@ function fmtWhen(iso: string): string {
 }
 
 // Wrap a pillar name to <=~16-char lines so long titles like
-// "Domains & Stewardship" don't clip off the radar chart.
+// "Relationships & Modeling" don't clip off the radar chart.
 function wrapLabel(text: string, maxChars = 16): string[] {
   const words = text.split(' ');
   const lines: string[] = [];
@@ -144,9 +144,11 @@ export default function Scorecard({
   const radarData = useMemo(
     () =>
       config.pillars
-        // Drop score-exempt pillars (e.g. the Beta Pages placeholder) — they
-        // carry no real score and would show as a misleading 0 on the radar.
-        .filter((p) => !pillarsByKey[p.key]?.score_exempt)
+        // Only plot pillars actually present in this scorecard, and drop
+        // score-exempt ones (e.g. the Beta Pages placeholder). This also guards a
+        // snapshot saved before a pillar existed (old run loaded after an upgrade):
+        // without the presence check it would plot a misleading 0 spoke.
+        .filter((p) => pillarsByKey[p.key] && !pillarsByKey[p.key]?.score_exempt)
         .map((p) => ({
           // Use the pillar's card title (name), not its long description, so the
           // radar labels match the scored pillar cards below.
@@ -479,12 +481,24 @@ export default function Scorecard({
         {config.pillars.map((cp) => {
           const p = pillarsByKey[cp.key];
           if (!p) {
+            // Still streaming → show the loading skeleton. But on a completed
+            // scorecard a missing pillar means this snapshot predates it (e.g. an
+            // old run saved before Pages existed, loaded after an upgrade): there's
+            // nothing to wait for, so show a muted "not in this assessment" instead
+            // of a spinner that never resolves.
+            const waiting = phase === 'running';
             return (
               <div key={cp.key} className="card flex items-center gap-4 px-4 py-3 opacity-70">
-                <Loader2 size={16} className="animate-spin text-ink-300 shrink-0 w-12" />
+                {waiting ? (
+                  <Loader2 size={16} className="animate-spin text-ink-300 shrink-0 w-12" />
+                ) : (
+                  <div className="w-12 text-center shrink-0 text-lg font-bold text-ink-300">—</div>
+                )}
                 <div className="flex-1 min-w-0">
                   <span className="font-semibold text-ink-500">{cp.name}</span>
-                  <p className="text-xs text-ink-400 mt-0.5 truncate">Checking…</p>
+                  <p className="text-xs text-ink-400 mt-0.5 truncate">
+                    {waiting ? 'Checking…' : 'Not in this assessment'}
+                  </p>
                 </div>
               </div>
             );

--- a/app/frontend/src/types.ts
+++ b/app/frontend/src/types.ts
@@ -12,6 +12,9 @@ export interface ConfigPillar {
   short: string;
   weight: number;
   capability: string;
+  // True for a pillar shown but excluded from the score (e.g. the Beta Pages
+  // placeholder). Lets the radar drop it from first render, before its event.
+  score_exempt?: boolean;
 }
 
 export interface AppConfig {

--- a/app/frontend/src/types.ts
+++ b/app/frontend/src/types.ts
@@ -59,6 +59,10 @@ export interface PillarScore {
   level: number;
   level_label: string;
   available: boolean;
+  // True when the pillar is shown/explained but deliberately excluded from the
+  // overall score (e.g. a placeholder probe for a Beta capability with no
+  // detection API yet). Render it as "Beta · not scored", not a failing L0.
+  score_exempt?: boolean;
   note: string | null;
   signals: Signal[];
   gaps: string[];

--- a/app/server/assessment/probes.py
+++ b/app/server/assessment/probes.py
@@ -957,6 +957,38 @@ async def probe_adoption() -> dict:
         return _empty(f"Could not read adoption signals ({str(e)[:120]}).")
 
 
+async def probe_pages() -> dict:
+    """Placeholder probe for the Pages & Business Concepts pillar.
+
+    Pages — governed, authoritative definitions of business concepts (terms,
+    entities, acronyms) and the human-modeled, *cited* layer of Genie Ontology —
+    are a Beta Unity Catalog Semantics feature with no public metadata API (no
+    information_schema view, system table, or documented REST endpoint) as of
+    this writing, so there is no reliable read-only signal to score yet.
+
+    We return score_exempt=True: scoring.py shows and explains the pillar but
+    EXCLUDES it from the overall score, so this top-weighted-but-unmeasurable
+    pillar never drags the headline number down. When a detection API lands,
+    replace this with a real probe and drop score_exempt so Pages counts at its
+    full weight. Docs: https://docs.databricks.com/aws/en/uc-semantics/pages
+    """
+    return {
+        "available": False,
+        "score_exempt": True,
+        "score": 0.0,
+        "signals": [],
+        "gaps": [
+            "Pages readiness can't be auto-detected yet (Beta; no public metadata API) — assess it manually via the Learn tab.",
+            "Have an account admin enable Pages (Previews), then author governed Pages for your top business concepts, terms, and acronyms.",
+            "Give each Page an owner and a domain, link related metrics/tables, and publish + certify the canonical definitions so Genie One cites them over inferred context.",
+        ],
+        "note": ("Pages is a Beta Unity Catalog Semantics feature with no public metadata API yet, so it is "
+                 "explained and planned for here but not scored automatically. See the Learn tab and "
+                 "https://docs.databricks.com/aws/en/uc-semantics/pages."),
+        "metrics": {},
+    }
+
+
 # Map pillar key -> probe coroutine
 PROBES = {
     "uc_foundation": probe_uc_foundation,
@@ -965,5 +997,6 @@ PROBES = {
     "metrics": probe_metrics,
     "genie_agents": probe_genie_agents,
     "domains": probe_domains,
+    "pages": probe_pages,
     "adoption": probe_adoption,
 }

--- a/app/server/assessment/scoring.py
+++ b/app/server/assessment/scoring.py
@@ -48,6 +48,15 @@ def _assemble_pillar(pillar_def: dict, probe: dict) -> dict:
         "level": level,
         "level_label": LEVEL_LABELS[level],
         "available": tech_available,
+        # score_exempt pillars are shown and explained but excluded from the
+        # overall score (e.g. a placeholder probe for a capability with no
+        # detection API yet). Keeps a top-weighted-but-unmeasurable pillar from
+        # dragging the headline number. See _finalize and pillars.py.
+        #
+        # Authoritative source is the pillar definition, so the exemption
+        # survives even when a probe raises and is replaced by _error_probe
+        # (which carries no flag); the probe result may also assert it.
+        "score_exempt": bool(pillar_def.get("score_exempt") or probe.get("score_exempt")),
         "note": probe.get("note"),
         "signals": probe.get("signals", []),
         "gaps": probe.get("gaps", []),
@@ -58,15 +67,24 @@ def _assemble_pillar(pillar_def: dict, probe: dict) -> dict:
 
 
 def _finalize(pillars_out: list[dict]) -> dict:
-    """Compute the overall score + prioritized gaps from all pillar entries."""
-    weighted_sum = sum(p["score"] * p["weight"] for p in pillars_out)
-    weight_total = sum(p["weight"] for p in pillars_out)
+    """Compute the overall score + prioritized gaps from all pillar entries.
+
+    Pillars flagged score_exempt (e.g. a placeholder probe for a Beta capability
+    with no detection API yet) are shown and explained but excluded from the
+    overall score and its weight denominator, so a top-weighted-but-unmeasurable
+    pillar never drags the headline number down. They are also kept out of the
+    auto-ranked top gaps (their guidance lives in Learn/Plan instead).
+    """
+    scored = [p for p in pillars_out if not p.get("score_exempt")]
+
+    weighted_sum = sum(p["score"] * p["weight"] for p in scored)
+    weight_total = sum(p["weight"] for p in scored)
     overall_score = round(weighted_sum / weight_total, 1) if weight_total else 0.0
     overall_level = level_from_score(overall_score)
     stage = readiness_stage(overall_score)
 
     # Prioritized gaps: lowest-scoring pillars first, weighted by importance.
-    ranked = sorted(pillars_out, key=lambda x: (x["score"], -x["weight"]))
+    ranked = sorted(scored, key=lambda x: (x["score"], -x["weight"]))
     top_gaps = []
     for pil in ranked:
         for g in pil["gaps"]:
@@ -81,6 +99,7 @@ def _finalize(pillars_out: list[dict]) -> dict:
             "readiness_stage": stage["label"],
             "readiness_detail": stage["detail"],
             "assessed_at": datetime.now(timezone.utc).isoformat(),
+            "excluded_pillars": [p["name"] for p in pillars_out if p.get("score_exempt")],
         },
         "top_gaps": top_gaps,
     }

--- a/app/server/content/library.py
+++ b/app/server/content/library.py
@@ -300,12 +300,40 @@ CAPABILITIES: dict[str, dict] = {
             {"title": "System tables reference (docs)", "url": "https://docs.databricks.com/aws/en/admin/system-tables/"},
         ],
     },
+    "pages": {
+        "name": "Pages & Business Concepts",
+        "tagline": "Governed, authoritative definitions of your business concepts — cited by Genie.",
+        "what": "A Page is a governed definition of a business concept — a critical term, entity, or acronym — authored in Unity Catalog. Pages are the human-modeled layer of Genie Ontology: structured fields (domain, owner, synonyms, description) plus a rich body, linked to the metrics and tables the concept depends on. When answering, Genie One prioritizes a Page's definition over context it infers automatically and cites the Page so users can confirm the source.",
+        "technical_value": "One authoritative definition per concept that agents reason over and cite — resolving conflicting or inferred definitions and raising answer trust.",
+        "business_value": "A shared business vocabulary: everyone (and every agent) uses the same definition of 'active user', 'qualified lead', or 'net revenue', with a named owner and an auditable source.",
+        "technical_enablement": [
+            "Have an account admin enable Pages (Previews), then author Pages for your highest-traffic terms, entities, and acronyms.",
+            "Give each Page an owner and place it in the right domain/subdomain; add synonyms and link the related metrics, tables, and sources.",
+            "Publish the canonical definitions (draft Pages stay private) and certify them so Genie One prefers and cites them.",
+            "Use AI-assisted bulk import to extract terms from an existing glossary or documents, then dedupe and resolve conflicts.",
+        ],
+        "business_adoption": [
+            "Start with the handful of contested metrics that cause the most 'which number is right?' debates.",
+            "Name an owner per concept and route edit suggestions and comments through them so definitions stay trusted and current.",
+            "Review Genie One answers for citations — where it cites a Page the definition is landing; where it doesn't, author or publish one.",
+        ],
+        "best_practices": [
+            "Author Pages for the concepts people argue about first — authority beats coverage early on.",
+            "Every published Page has an owner, a domain, synonyms, and links to the metrics/tables it defines.",
+            "Publish and certify canonical definitions so Genie One cites them over inferred context; keep drafts private until they're ready.",
+            "Keep Pages fresh — a stale authoritative definition is worse than none; use the review/suggestion workflow.",
+        ],
+        "sources": [
+            {"title": "Pages (Unity Catalog Semantics docs)", "url": "https://docs.databricks.com/aws/en/uc-semantics/pages"},
+            {"title": "Introducing Genie One, Genie Agents, and Genie Ontology (blog)", "url": "https://www.databricks.com/blog/introducing-genie-one-genie-ontology-and-genie-agents"},
+        ],
+    },
 }
 
 # Display order for the Learn tab.
 CAPABILITY_ORDER = [
     "ontology", "unity_catalog", "metadata", "relationships",
-    "metric_views", "genie_agents", "domains", "adoption",
+    "metric_views", "genie_agents", "domains", "pages", "adoption",
 ]
 
 

--- a/app/server/content/methodology.py
+++ b/app/server/content/methodology.py
@@ -115,6 +115,12 @@ PRACTICES: dict[str, list[str]] = {
         "Name metric views {subdomain}_{kpi_group}; tag agents and metric views with their domain for discoverability and observability.",
         "Assign a named owner/steward per domain and certify the canonical assets so the agent (and users) know what to trust.",
     ],
+    "pages": [
+        "Author a Page for each contested business concept — a governed, owned definition beats a dozen inferred ones.",
+        "Give every published Page an owner and a domain; add synonyms and link the metrics/tables it defines.",
+        "Publish and certify canonical definitions so Genie One cites them over inferred context; keep unfinished Pages as drafts.",
+        "Keep definitions fresh via the review/suggestion workflow — Genie One trusts and cites Pages, so stale ones mislead.",
+    ],
 }
 
 
@@ -146,6 +152,7 @@ def methodology_prompt() -> str:
         "comment at view/dimension/measure level and add synonyms; build a base view (CTEs) first for multi-fact/nested KPIs, then the metric view on top; "
         "one Genie Agent per domain (<=30 items) with a description; save validated queries as example SQL and keep it simple; "
         "structure agent instructions as trigger->action->example; benchmark 2-4 phrasings per question with ground-truth SQL and regression-test after every change; "
-        "name metric views {subdomain}_{kpi_group} and tag agents/metric views with their domain; certify canonical assets and name a steward per domain."
+        "name metric views {subdomain}_{kpi_group} and tag agents/metric views with their domain; certify canonical assets and name a steward per domain; "
+        "author and certify Pages for the business concepts users argue about so Genie One cites authoritative definitions over inferred ones."
     )
     return "\n".join(lines)

--- a/app/server/pillars.py
+++ b/app/server/pillars.py
@@ -48,49 +48,78 @@ READINESS_STAGES = [
     },
 ]
 
-# Relative weight of each pillar in the overall score (sums to 100).
+# Relative weight of each pillar in the overall score. Weights sum to 100, but a
+# score_exempt pillar (see the NOTE below) is excluded from the live score's
+# weight denominator — so today the headline number normalizes over 84, not 100.
+#
+# Weighting reflects what most determines Genie Ontology readiness: the
+# ontology-modeled layers the customer authors and governs — Metrics (metric
+# views), Domains & Stewardship, and Pages & Business Concepts — carry
+# the most weight, followed by Metadata Richness. The infrastructural (UC
+# foundation, relationships), consumption (Genie Agents), and activity
+# (adoption) pillars weigh less.
+#
+# NOTE on Pages: it is intentionally in the top weight tier, but its probe is
+# currently a placeholder (Pages is a Beta UC Semantics feature with no public
+# metadata API). While a probe returns "score_exempt", scoring.py excludes that
+# pillar from the overall score entirely — so the placeholder does NOT drag the
+# headline number. Remove the score_exempt flag from probe_pages once real
+# detection lands and Pages will count at its full weight.
 PILLARS = [
     {
         "key": "uc_foundation",
         "name": "Unity Catalog Foundation",
-        "weight": 15,
+        "weight": 10,
         "short": "Governed catalogs, schemas, and tables in Unity Catalog.",
         "capability": "unity_catalog",
     },
     {
         "key": "metadata",
         "name": "Metadata Richness",
-        "weight": 22,
+        "weight": 15,
         "short": "Comments and descriptions on tables and columns, plus tags.",
         "capability": "metadata",
     },
     {
         "key": "relationships",
         "name": "Relationships & Modeling",
-        "weight": 12,
+        "weight": 7,
         "short": "Primary/foreign keys and a curated gold layer for analytics.",
         "capability": "relationships",
     },
     {
         "key": "metrics",
         "name": "Metrics",
-        "weight": 20,
+        "weight": 18,
         "short": "Metric views — the governed metrics foundation that feeds the ontology.",
         "capability": "metric_views",
     },
     {
         "key": "genie_agents",
         "name": "Genie Agents",
-        "weight": 16,
+        "weight": 12,
         "short": "Curated Genie Agents with instructions, example SQL, and benchmarks.",
         "capability": "genie_agents",
     },
     {
         "key": "domains",
         "name": "Domains & Stewardship",
-        "weight": 10,
+        "weight": 17,
         "short": "Business-aligned domains with named stewards and certification.",
         "capability": "domains",
+    },
+    {
+        "key": "pages",
+        "name": "Pages & Business Concepts",
+        "weight": 16,
+        "short": "Governed Pages defining business concepts, terms, and acronyms — the authoritative layer Genie One cites over inferred context.",
+        "capability": "pages",
+        # Authoritative exemption flag: scoring excludes this pillar from the
+        # overall score while it is unmeasurable (placeholder probe). Set here on
+        # the definition — not only on the probe — so the exemption holds even if
+        # the probe raises and falls back to _error_probe. Drop it (and the
+        # placeholder in probe_pages) once a real detection signal exists.
+        "score_exempt": True,
     },
     {
         "key": "adoption",

--- a/app/server/routes/config.py
+++ b/app/server/routes/config.py
@@ -29,6 +29,10 @@ async def get_config():
                 "short": p["short"],
                 "weight": p["weight"],
                 "capability": p["capability"],
+                # Expose the score-exempt flag so the UI can exclude a Beta
+                # placeholder pillar (e.g. Pages) from the radar from first render,
+                # before its stream event arrives.
+                "score_exempt": bool(p.get("score_exempt")),
             }
             for p in PILLARS
         ],

--- a/app/server/routes/plan.py
+++ b/app/server/routes/plan.py
@@ -50,6 +50,16 @@ def _scorecard_digest(sc: Optional[dict]) -> str:
     overall = sc.get("overall", {})
     lines = [f"Overall readiness: {overall.get('score')}/100 ({overall.get('level_label')}) — {overall.get('readiness_stage')}."]
     for p in sc.get("pillars", []):
+        # Score-exempt pillars (e.g. the Beta Pages placeholder) carry no real
+        # score and are excluded from the overall number and top gaps. Present
+        # them as "not scored" so the plan LLM can still recommend them where
+        # relevant but never treats a placeholder 0 as the worst-scoring gap.
+        if p.get("score_exempt"):
+            lines.append(
+                f"- {p.get('name')}: not scored (Beta capability — include in the plan where "
+                f"relevant, but it does not affect the readiness score)"
+            )
+            continue
         sigs = ", ".join(f"{s.get('label')}={s.get('value')}{s.get('unit','')}" for s in (p.get("signals") or [])[:3])
         avail = "" if p.get("available", True) else " [not available]"
         line = f"- {p.get('name')}: {p.get('score')} ({p.get('level_label')}){avail}"


### PR DESCRIPTION
## Summary
Adds **UC Semantics Pages** as an 8th readiness pillar. **Stacked on #3** (product-naming) — base is `feat/rename`, so this diff is Pages-only; merge #3 first.

- **New "Pages & Business Concepts" pillar (Beta).** Placeholder probe — Pages has no public metadata API yet — carrying a `score_exempt` flag: the pillar is shown, explained, and planned for, but **excluded from the overall score, the auto top-gaps, and the radar** until real detection exists. The exemption is authoritative on the pillar definition, so it survives even if a probe raises (falls back to `_error_probe`).
- **Reweight** so the ontology-modeled layers rank highest: Metrics 18, Domains 17, Pages 16, Metadata 15 (weights sum to 100; the live score normalizes over the 84 non-exempt).
- **Learn/Plan wiring:** capability entry + methodology practices; the plan digest presents `score_exempt` pillars as "not scored" so the LLM never treats a placeholder 0 as the top gap. Frontend renders Pages as a neutral "Beta · not scored" card and drops it from the radar.

## Isaac Review — addressed
Ran Isaac Review on the combined change; it confirmed the `score_exempt` mechanism is correct (weights sum to 100, normalizes over 84, exemption survives probe crashes, radar/plan/top-gaps all exclude it). Findings fixed here: pillar-count copy 7→8 (Assess intro, Help panel, README, CLAUDE); the `wrapLabel` radar-label example; and documenting that the `score_exempt` Pages pillar is intentionally exempt from the accelerator-coverage test (Pages ships Learn guidance but no runnable accelerator yet).

## Validation
- Python: 8 pillars, weights sum to 100; Pages `score_exempt` excluded from the overall score (verified even on a simulated probe crash); single per-request source resolution intact.
- Frontend: `tsc --noEmit` clean, 16/16 vitest, production build green.

This pull request and its description were written by Isaac.
