### PR TITLE
Plan: work from the in-session assessment when history isn't saved

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -121,7 +121,7 @@ export default function App() {
         </div>
         {planMounted && (
           <div className={tab === 'plan' ? '' : 'hidden'}>
-            <PlanWizard model={activeModel} active={tab === 'plan'} />
+            <PlanWizard model={activeModel} active={tab === 'plan'} scorecard={scorecard} />
           </div>
         )}
         {tab === 'learn' && <CapabilityExplainer scorecard={scorecard} />}

--- a/app/frontend/src/components/PlanWizard.tsx
+++ b/app/frontend/src/components/PlanWizard.tsx
@@ -8,6 +8,7 @@ import type {
   PlanListItem,
   PlanDetail,
   PlanSaveResponse,
+  Scorecard as ScorecardType,
 } from '../types';
 import Markdown from './Markdown';
 import Spinner from './Spinner';
@@ -19,7 +20,16 @@ function fmtWhen(iso: string): string {
   return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
 
-export default function PlanWizard({ model, active }: { model: string; active: boolean }) {
+export default function PlanWizard({
+  model,
+  active,
+  scorecard,
+}: {
+  model: string;
+  active: boolean;
+  scorecard: ScorecardType | null;
+}) {
+
   const [assessments, setAssessments] = useState<HistorySnapshot[]>([]);
   const [plans, setPlans] = useState<PlanListItem[]>([]);
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<number | null>(null);
@@ -30,6 +40,11 @@ export default function PlanWizard({ model, active }: { model: string; active: b
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [currentPlanId, setCurrentPlanId] = useState<number | null>(null);
+
+  // No saved history (e.g. no Lakebase) but an assessment was run this session →
+  // generate the plan from that in-session scorecard instead of a stored snapshot.
+  const fromCurrent = assessments.length === 0 && !!scorecard;
+  const currentScore = scorecard ? Math.round(scorecard.overall.score) : null;
 
   function refreshPlans() {
     apiGet<PlansResponse>('/plan/list').then((r) => setPlans(r.plans || [])).catch(() => {});
@@ -83,29 +98,32 @@ export default function PlanWizard({ model, active }: { model: string; active: b
   }
 
   async function generate() {
-    if (generating || selectedSnapshotId == null) return;
+    // Need either a selected saved snapshot, or an in-session assessment to use.
+    if (generating || (!fromCurrent && selectedSnapshotId == null)) return;
     setError(null);
     setOutput('');
     setCurrentPlanId(null);
     setGenerating(true);
     let acc = '';
+    // Generate from the in-session scorecard when there's no saved history,
+    // otherwise from the selected saved snapshot.
+    const genBody = fromCurrent ? { scorecard } : { snapshot_id: selectedSnapshotId };
     try {
-      for await (const chunk of streamPost('/plan/generate', { snapshot_id: selectedSnapshotId }, model)) {
+      for await (const chunk of streamPost('/plan/generate', genBody, model)) {
         acc += chunk;
         setOutput(acc);
       }
       if (acc.trim()) {
         try {
-          const res = await apiPost<PlanSaveResponse>(
-            '/plan/save',
-            { snapshot_id: selectedSnapshotId, title: titleFor(selectedSnapshotId), markdown: acc },
-            model
-          );
+          const saveBody = fromCurrent
+            ? { snapshot_id: null, title: PLAN_TITLE, markdown: acc }
+            : { snapshot_id: selectedSnapshotId, title: titleFor(selectedSnapshotId), markdown: acc };
+          const res = await apiPost<PlanSaveResponse>('/plan/save', saveBody, model);
           if (res.id != null) setCurrentPlanId(res.id);
           setMode('view');
           refreshPlans();
         } catch {
-          /* saving is best-effort; the plan is still shown */
+          /* saving is best-effort (needs Lakebase); the plan is still shown */
         }
       }
     } catch (e) {
@@ -160,8 +178,8 @@ export default function PlanWizard({ model, active }: { model: string; active: b
     }
   }
 
-  // No assessments yet → point the user at the Assess tab.
-  if (assessments.length === 0) {
+  // No saved assessments AND nothing run this session → point the user at Assess.
+  if (assessments.length === 0 && !scorecard) {
     return (
       <div className="card max-w-2xl mx-auto mt-10 p-8 text-center">
         <div className="w-12 h-12 rounded-xl bg-databricks-50 flex items-center justify-center mx-auto mb-4">
@@ -226,25 +244,33 @@ export default function PlanWizard({ model, active }: { model: string; active: b
             </div>
             <h2 className="text-xl font-bold text-ink-900">Generate an action plan</h2>
             <p className="text-sm text-ink-600 mt-2 leading-relaxed">
-              Pick the assessment to base this plan on. The plan is generated with AI from that
-              assessment's scores and gaps, with clear tactical steps and the Databricks accelerators
-              that close each gap.
+              {fromCurrent
+                ? 'The plan is generated with AI from your current assessment’s scores and gaps, with clear tactical steps and the Databricks accelerators that close each gap.'
+                : 'Pick the assessment to base this plan on. The plan is generated with AI from that assessment’s scores and gaps, with clear tactical steps and the Databricks accelerators that close each gap.'}
             </p>
 
             <label className="block mt-5 text-xs font-semibold uppercase tracking-wider text-ink-400 mb-1.5">
               Base assessment
             </label>
-            <select
-              value={selectedSnapshotId ?? ''}
-              onChange={(e) => setSelectedSnapshotId(Number(e.target.value))}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-databricks-300"
-            >
-              {assessments.map((a) => (
-                <option key={a.id} value={Number(a.id)}>
-                  {Math.round(a.overall_score)}/100 · {fmtWhen(a.created_at)}
-                </option>
-              ))}
-            </select>
+            {fromCurrent ? (
+              <div className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-ink-700 flex items-center gap-2">
+                <Gauge size={14} className="text-databricks-500 shrink-0" />
+                Current assessment{currentScore != null ? ` · ${currentScore}/100` : ''}
+                <span className="text-ink-400">(this session)</span>
+              </div>
+            ) : (
+              <select
+                value={selectedSnapshotId ?? ''}
+                onChange={(e) => setSelectedSnapshotId(Number(e.target.value))}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-databricks-300"
+              >
+                {assessments.map((a) => (
+                  <option key={a.id} value={Number(a.id)}>
+                    {Math.round(a.overall_score)}/100 · {fmtWhen(a.created_at)}
+                  </option>
+                ))}
+              </select>
+            )}
 
             {error && (
               <p className="mt-4 text-sm text-red-600 flex items-center gap-1.5">
@@ -254,13 +280,18 @@ export default function PlanWizard({ model, active }: { model: string; active: b
 
             <button
               onClick={generate}
-              disabled={generating || selectedSnapshotId == null}
+              disabled={generating || (!fromCurrent && selectedSnapshotId == null)}
               className="btn-primary mt-5 inline-flex items-center gap-2"
             >
               <Sparkles size={16} />
               {generating ? 'Generating…' : 'Generate plan'}
             </button>
-            <p className="text-xs text-ink-400 mt-3">Uses your workspace's Foundation Model API. The plan is saved to your history.</p>
+            <p className="text-xs text-ink-400 mt-3">
+              Uses your workspace's Foundation Model API.{' '}
+              {fromCurrent
+                ? 'No Lakebase is attached, so this plan lives only in this session (export it to keep a copy).'
+                : 'The plan is saved to your history.'}
+            </p>
           </div>
         ) : (
           // ---- Viewing / streaming a plan ----------------------------------
@@ -281,7 +312,10 @@ export default function PlanWizard({ model, active }: { model: string; active: b
               )}
             </div>
             <p className="text-xs text-ink-400 flex items-center gap-1 mb-4">
-              <Link2 size={11} /> Based on assessment · {labelForSnapshot(selectedSnapshotId)}
+              <Link2 size={11} /> Based on assessment ·{' '}
+              {fromCurrent
+                ? `Current assessment${currentScore != null ? ` · ${currentScore}/100` : ''}`
+                : labelForSnapshot(selectedSnapshotId)}
             </p>
 
             {error && (

--- a/app/frontend/src/components/PlanWizard.tsx
+++ b/app/frontend/src/components/PlanWizard.tsx
@@ -52,14 +52,13 @@ export default function PlanWizard({
   // `fromCurrent`/history state changes later in the session.
   const [viewBasis, setViewBasis] = useState<string | null>(null);
 
-  // Use the in-session scorecard when history loaded and is genuinely empty (e.g. no
-  // Lakebase), OR when the history fetch failed — on error prefer letting the user
-  // generate from this session over blocking them (the rare cost is a
-  // Lakebase-present save that lacks a snapshot link). While still 'loading',
-  // fromCurrent stays false and the UI shows a spinner rather than deciding.
-  const fromCurrent =
-    !!scorecard &&
-    ((historyStatus === 'loaded' && assessments.length === 0) || historyStatus === 'error');
+  // Use the in-session scorecard only when there are NO saved snapshots to pick
+  // from and history is no longer loading. Empty covers both 'loaded && empty'
+  // (e.g. no Lakebase) and a failed fetch that never populated `assessments` — in
+  // the failure case we still let the user generate from this session rather than
+  // block them. Crucially this stays false whenever `assessments` is populated
+  // (even if a later refetch errored), so a real snapshot picker is never discarded.
+  const fromCurrent = !!scorecard && assessments.length === 0 && historyStatus !== 'loading';
   const currentScore = scorecard ? Math.round(scorecard.overall.score) : null;
   // Single source of truth for the "Current assessment · N/100" base label, so the
   // composer and the view-pane provenance line can't drift.
@@ -210,10 +209,13 @@ export default function PlanWizard({
     }
   }
 
-  // History still loading with nothing to show yet → spinner, so we don't flash
-  // "run an assessment first" before /assess/history resolves (it would show even
-  // when saved history exists).
-  if (historyStatus === 'loading' && assessments.length === 0 && !scorecard) {
+  // While history is loading, show a spinner rather than deciding what to render —
+  // this avoids both a premature "run an assessment first" flash (when saved history
+  // exists) and a flash of an empty base-assessment dropdown (when a scorecard
+  // exists but snapshots haven't loaded yet). historyStatus only sits at 'loading'
+  // until the first resolve; later refetches keep it 'loaded'/'error', so this
+  // doesn't re-spinner on tab revisits.
+  if (historyStatus === 'loading') {
     return (
       <div className="card max-w-2xl mx-auto mt-10 p-8 text-center">
         <Spinner label="Loading…" />

--- a/app/frontend/src/components/PlanWizard.tsx
+++ b/app/frontend/src/components/PlanWizard.tsx
@@ -31,6 +31,12 @@ export default function PlanWizard({
 }) {
 
   const [assessments, setAssessments] = useState<HistorySnapshot[]>([]);
+  // Whether /assess/history has resolved successfully at least once. Distinguishes
+  // "history loaded and genuinely empty" (→ use the in-session scorecard) from
+  // "not loaded yet / fetch failed" (→ don't assume there's no history and silently
+  // save a plan with no snapshot link). Note: without Lakebase the endpoint returns
+  // 200 with an empty list, so the in-session path still engages there.
+  const [assessmentsLoaded, setAssessmentsLoaded] = useState(false);
   const [plans, setPlans] = useState<PlanListItem[]>([]);
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<number | null>(null);
   const [mode, setMode] = useState<'new' | 'view'>('new');
@@ -47,7 +53,9 @@ export default function PlanWizard({
 
   // No saved history (e.g. no Lakebase) but an assessment was run this session →
   // generate the plan from that in-session scorecard instead of a stored snapshot.
-  const fromCurrent = assessments.length === 0 && !!scorecard;
+  // Gate on a successful history load so a not-yet-loaded / failed fetch isn't
+  // mistaken for "no history" (which would drop a real snapshot link on save).
+  const fromCurrent = assessmentsLoaded && assessments.length === 0 && !!scorecard;
   const currentScore = scorecard ? Math.round(scorecard.overall.score) : null;
   // Single source of truth for the "Current assessment · N/100" base label, so the
   // composer and the view-pane provenance line can't drift.
@@ -63,6 +71,7 @@ export default function PlanWizard({
       .then((h) => {
         const snaps = h.snapshots || [];
         setAssessments(snaps);
+        setAssessmentsLoaded(true);
         // Default to the newest assessment; keep the current selection if it still exists.
         setSelectedSnapshotId((cur) =>
           cur != null && snaps.some((s) => Number(s.id) === cur)

--- a/app/frontend/src/components/PlanWizard.tsx
+++ b/app/frontend/src/components/PlanWizard.tsx
@@ -40,11 +40,19 @@ export default function PlanWizard({
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [currentPlanId, setCurrentPlanId] = useState<number | null>(null);
+  // Provenance label frozen at the moment a plan is generated or loaded, so the
+  // view pane keeps showing what THIS plan was actually based on even if the live
+  // `fromCurrent`/history state changes later in the session.
+  const [viewBasis, setViewBasis] = useState<string | null>(null);
 
   // No saved history (e.g. no Lakebase) but an assessment was run this session →
   // generate the plan from that in-session scorecard instead of a stored snapshot.
   const fromCurrent = assessments.length === 0 && !!scorecard;
   const currentScore = scorecard ? Math.round(scorecard.overall.score) : null;
+  // Single source of truth for the "Current assessment · N/100" base label, so the
+  // composer and the view-pane provenance line can't drift.
+  const currentBaseLabel = (score: number | null) =>
+    `Current assessment${score != null ? ` · ${score}/100` : ''}`;
 
   function refreshPlans() {
     apiGet<PlansResponse>('/plan/list').then((r) => setPlans(r.plans || [])).catch(() => {});
@@ -100,14 +108,24 @@ export default function PlanWizard({
   async function generate() {
     // Need either a selected saved snapshot, or an in-session assessment to use.
     if (generating || (!fromCurrent && selectedSnapshotId == null)) return;
+    // Freeze the basis at generation time: the stream body, the saved metadata, and
+    // the displayed provenance all use these captured values, so nothing shifts if
+    // `fromCurrent`/history resolves differently mid-stream.
+    const genFromCurrent = fromCurrent;
+    const genSnapshotId = selectedSnapshotId;
+    const genBasisLabel = genFromCurrent ? currentBaseLabel(currentScore) : labelForSnapshot(genSnapshotId);
     setError(null);
     setOutput('');
     setCurrentPlanId(null);
+    setViewBasis(genBasisLabel);
+    // Switch to the view pane BEFORE streaming so the plan renders live as it
+    // arrives and survives a save failure (saving is best-effort). Previously
+    // setMode('view') ran only after /plan/save resolved, so streaming was never
+    // shown and a save error discarded the generated plan.
+    setMode('view');
     setGenerating(true);
     let acc = '';
-    // Generate from the in-session scorecard when there's no saved history,
-    // otherwise from the selected saved snapshot.
-    const genBody = fromCurrent ? { scorecard } : { snapshot_id: selectedSnapshotId };
+    const genBody = genFromCurrent ? { scorecard } : { snapshot_id: genSnapshotId };
     try {
       for await (const chunk of streamPost('/plan/generate', genBody, model)) {
         acc += chunk;
@@ -115,12 +133,11 @@ export default function PlanWizard({
       }
       if (acc.trim()) {
         try {
-          const saveBody = fromCurrent
+          const saveBody = genFromCurrent
             ? { snapshot_id: null, title: PLAN_TITLE, markdown: acc }
-            : { snapshot_id: selectedSnapshotId, title: titleFor(selectedSnapshotId), markdown: acc };
+            : { snapshot_id: genSnapshotId, title: titleFor(genSnapshotId), markdown: acc };
           const res = await apiPost<PlanSaveResponse>('/plan/save', saveBody, model);
           if (res.id != null) setCurrentPlanId(res.id);
-          setMode('view');
           refreshPlans();
         } catch {
           /* saving is best-effort (needs Lakebase); the plan is still shown */
@@ -141,6 +158,8 @@ export default function PlanWizard({
       setOutput(p.plan_markdown);
       setCurrentPlanId(p.id);
       if (p.snapshot_id != null) setSelectedSnapshotId(p.snapshot_id);
+      // Freeze this loaded plan's provenance from its own linked snapshot.
+      setViewBasis(labelForSnapshot(p.snapshot_id));
       setMode('view');
     } catch (e) {
       setError((e as Error).message);
@@ -255,7 +274,7 @@ export default function PlanWizard({
             {fromCurrent ? (
               <div className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-ink-700 flex items-center gap-2">
                 <Gauge size={14} className="text-databricks-500 shrink-0" />
-                Current assessment{currentScore != null ? ` · ${currentScore}/100` : ''}
+                {currentBaseLabel(currentScore)}
                 <span className="text-ink-400">(this session)</span>
               </div>
             ) : (
@@ -312,10 +331,7 @@ export default function PlanWizard({
               )}
             </div>
             <p className="text-xs text-ink-400 flex items-center gap-1 mb-4">
-              <Link2 size={11} /> Based on assessment ·{' '}
-              {fromCurrent
-                ? `Current assessment${currentScore != null ? ` · ${currentScore}/100` : ''}`
-                : labelForSnapshot(selectedSnapshotId)}
+              <Link2 size={11} /> Based on assessment · {viewBasis ?? '—'}
             </p>
 
             {error && (

--- a/app/frontend/src/components/PlanWizard.tsx
+++ b/app/frontend/src/components/PlanWizard.tsx
@@ -31,12 +31,13 @@ export default function PlanWizard({
 }) {
 
   const [assessments, setAssessments] = useState<HistorySnapshot[]>([]);
-  // Whether /assess/history has resolved successfully at least once. Distinguishes
-  // "history loaded and genuinely empty" (→ use the in-session scorecard) from
-  // "not loaded yet / fetch failed" (→ don't assume there's no history and silently
-  // save a plan with no snapshot link). Note: without Lakebase the endpoint returns
-  // 200 with an empty list, so the in-session path still engages there.
-  const [assessmentsLoaded, setAssessmentsLoaded] = useState(false);
+  // Load state of /assess/history: 'loading' until the first resolve, then 'loaded'
+  // (success — the list may be empty) or 'error' (fetch failed). Lets us (a) show a
+  // spinner instead of a premature "run an assessment first" flash, and (b) on
+  // error fall back to the in-session path rather than blocking the user. Without
+  // Lakebase the endpoint returns 200 with an empty list, so it resolves to 'loaded'
+  // and the in-session path still engages.
+  const [historyStatus, setHistoryStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
   const [plans, setPlans] = useState<PlanListItem[]>([]);
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<number | null>(null);
   const [mode, setMode] = useState<'new' | 'view'>('new');
@@ -51,11 +52,14 @@ export default function PlanWizard({
   // `fromCurrent`/history state changes later in the session.
   const [viewBasis, setViewBasis] = useState<string | null>(null);
 
-  // No saved history (e.g. no Lakebase) but an assessment was run this session →
-  // generate the plan from that in-session scorecard instead of a stored snapshot.
-  // Gate on a successful history load so a not-yet-loaded / failed fetch isn't
-  // mistaken for "no history" (which would drop a real snapshot link on save).
-  const fromCurrent = assessmentsLoaded && assessments.length === 0 && !!scorecard;
+  // Use the in-session scorecard when history loaded and is genuinely empty (e.g. no
+  // Lakebase), OR when the history fetch failed — on error prefer letting the user
+  // generate from this session over blocking them (the rare cost is a
+  // Lakebase-present save that lacks a snapshot link). While still 'loading',
+  // fromCurrent stays false and the UI shows a spinner rather than deciding.
+  const fromCurrent =
+    !!scorecard &&
+    ((historyStatus === 'loaded' && assessments.length === 0) || historyStatus === 'error');
   const currentScore = scorecard ? Math.round(scorecard.overall.score) : null;
   // Single source of truth for the "Current assessment · N/100" base label, so the
   // composer and the view-pane provenance line can't drift.
@@ -71,7 +75,7 @@ export default function PlanWizard({
       .then((h) => {
         const snaps = h.snapshots || [];
         setAssessments(snaps);
-        setAssessmentsLoaded(true);
+        setHistoryStatus('loaded');
         // Default to the newest assessment; keep the current selection if it still exists.
         setSelectedSnapshotId((cur) =>
           cur != null && snaps.some((s) => Number(s.id) === cur)
@@ -81,7 +85,7 @@ export default function PlanWizard({
             : null
         );
       })
-      .catch(() => {});
+      .catch(() => setHistoryStatus('error'));
   }
 
   // Refetch whenever the Plan tab becomes active, so an assessment just run on the
@@ -204,6 +208,17 @@ export default function PlanWizard({
     } finally {
       setExporting(false);
     }
+  }
+
+  // History still loading with nothing to show yet → spinner, so we don't flash
+  // "run an assessment first" before /assess/history resolves (it would show even
+  // when saved history exists).
+  if (historyStatus === 'loading' && assessments.length === 0 && !scorecard) {
+    return (
+      <div className="card max-w-2xl mx-auto mt-10 p-8 text-center">
+        <Spinner label="Loading…" />
+      </div>
+    );
   }
 
   // No saved assessments AND nothing run this session → point the user at Assess.

--- a/app/server/routes/plan.py
+++ b/app/server/routes/plan.py
@@ -117,6 +117,15 @@ async def plan_generate(req: PlanGenerateRequest, x_forwarded_email: Optional[st
         scorecard = snap.get("scorecard") or {}
     elif req.scorecard is not None:
         scorecard = req.scorecard
+        # The inline scorecard is client-supplied (in-session assessment). Validate
+        # it actually has pillars — an empty/malformed dict passes `is not None` but
+        # would otherwise produce a generic "no assessment available" plan instead of
+        # a clear error.
+        if not isinstance(scorecard, dict) or not scorecard.get("pillars"):
+            return JSONResponse(
+                status_code=400,
+                content={"error": "The provided assessment is empty — run an assessment first."},
+            )
     else:
         return JSONResponse(
             status_code=400,

--- a/app/server/routes/plan.py
+++ b/app/server/routes/plan.py
@@ -25,7 +25,11 @@ router = APIRouter()
 
 
 class PlanGenerateRequest(BaseModel):
-    snapshot_id: int          # the assessment this plan is generated against
+    # A plan is generated against EITHER a saved assessment (snapshot_id) or an
+    # in-session assessment passed inline (scorecard). The inline path lets Plan
+    # work when history isn't persisted (no Lakebase attached).
+    snapshot_id: Optional[int] = None
+    scorecard: Optional[dict] = None
 
 
 class PlanSaveRequest(BaseModel):
@@ -99,21 +103,32 @@ Do not invent scores or accelerators that are not listed above. Be specific to t
 
 @router.post("/plan/generate")
 async def plan_generate(req: PlanGenerateRequest, x_forwarded_email: Optional[str] = Header(default=None)):
-    """Generate the action plan against a SELECTED, stored assessment (no conversation).
+    """Generate the action plan against an assessment (no conversation).
 
-    The scorecard is loaded server-side from the user's own snapshot, so a plan is
-    always tied to a real, persisted assessment.
+    The assessment comes from EITHER a saved snapshot (``snapshot_id``, loaded
+    server-side from the user's own history) or an inline ``scorecard`` sent by the
+    client — the latter lets the Plan tab work from the in-session assessment even
+    when history isn't persisted (no Lakebase attached).
     """
-    snap = await snapshots.get_snapshot(req.snapshot_id, created_by=x_forwarded_email)
-    if snap is None:
-        return JSONResponse(status_code=404, content={"error": "Assessment not found."})
-    scorecard = snap.get("scorecard") or {}
+    if req.snapshot_id is not None:
+        snap = await snapshots.get_snapshot(req.snapshot_id, created_by=x_forwarded_email)
+        if snap is None:
+            return JSONResponse(status_code=404, content={"error": "Assessment not found."})
+        scorecard = snap.get("scorecard") or {}
+    elif req.scorecard is not None:
+        scorecard = req.scorecard
+    else:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "Provide a snapshot_id or an assessment scorecard."},
+        )
     system = _generate_system(scorecard)
     messages = [
         {"role": "system", "content": system},
         {"role": "user", "content": "Generate the action plan now."},
     ]
-    logger.info("Plan generate for snapshot %s", req.snapshot_id)
+    logger.info("Plan generate for %s",
+                f"snapshot {req.snapshot_id}" if req.snapshot_id is not None else "in-session assessment")
     return StreamingResponse(
         stream_llm_chat(messages, max_tokens=2000, temperature=0.4),
         media_type="text/event-stream",

--- a/app/server/routes/plan.py
+++ b/app/server/routes/plan.py
@@ -116,20 +116,20 @@ async def plan_generate(req: PlanGenerateRequest, x_forwarded_email: Optional[st
             return JSONResponse(status_code=404, content={"error": "Assessment not found."})
         scorecard = snap.get("scorecard") or {}
     elif req.scorecard is not None:
+        # Client-supplied (in-session assessment, when history isn't persisted).
         scorecard = req.scorecard
-        # The inline scorecard is client-supplied (in-session assessment). Validate
-        # it actually has pillars — an empty/malformed dict passes `is not None` but
-        # would otherwise produce a generic "no assessment available" plan instead of
-        # a clear error.
-        if not isinstance(scorecard, dict) or not scorecard.get("pillars"):
-            return JSONResponse(
-                status_code=400,
-                content={"error": "The provided assessment is empty — run an assessment first."},
-            )
     else:
         return JSONResponse(
             status_code=400,
             content={"error": "Provide a snapshot_id or an assessment scorecard."},
+        )
+    # Validate the resolved scorecard from EITHER source has real content — an empty
+    # or malformed one (client dict, or a degraded/legacy snapshot) would otherwise
+    # stream a generic "no assessment available" plan instead of a clear error.
+    if not isinstance(scorecard, dict) or not scorecard.get("pillars"):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "The assessment is empty — run an assessment first."},
         )
     system = _generate_system(scorecard)
     messages = [


### PR DESCRIPTION
## Problem
The Plan tab was built entirely around **saved snapshots** (`/assess/history`). On a deploy without Lakebase — which is the **default** (`USE_LAKEBASE=false`) — history is always empty, so:
- the Plan tab shows *"Run an assessment first"* even right after running one, and
- `/plan/generate` hard-requires a `snapshot_id`.

Net: Plan is unusable out-of-the-box unless the operator attaches Lakebase.

## Fix
Let Plan generate from the **in-session assessment** the app already holds when there's no saved history.

- **`routes/plan.py`** — `PlanGenerateRequest.snapshot_id` is now optional; added `scorecard: Optional[dict]`. `/plan/generate` resolves the scorecard from the snapshot (if given) or the inline body, else returns `400`.
- **`App.tsx`** — passes the in-session `scorecard` into `PlanWizard`.
- **`PlanWizard.tsx`** — when there's no saved history but an assessment was run this session (`fromCurrent`): relaxed the "run an assessment first" gate, shows a **"Current assessment · N/100"** base instead of the snapshot dropdown, sends `{ scorecard }` to `/plan/generate`, and notes the plan lives only in-session (export to keep a copy).

**Saved-history behavior is unchanged** — when Lakebase is attached, the tab still lists and generates from saved snapshots exactly as before.

## Testing
- `tsc --noEmit` clean; `vitest` 16/16 pass; frontend builds.
- `plan.py` parses; the inline-scorecard branch and the 400-on-neither path are covered by the new request model.

## Note
Independent of the OBO PR (#5) — branches off `main`, touches disjoint files.

This pull request and its description were written by Isaac.