### PR TITLE
Progressive chunked metadata scan (fix hang/network-error on wide metastores)

### DIFF
--- a/app/frontend/src/components/Scorecard.tsx
+++ b/app/frontend/src/components/Scorecard.tsx
@@ -30,6 +30,7 @@ import PillarDetail from './PillarDetail';
 
 type AssessEvent =
   | { type: 'pillar'; pillar: PillarScore }
+  | { type: 'pillar_progress'; key: string; done: number; total: number; detail: string }
   | { type: 'complete'; overall: ScorecardOverall; pillars: PillarScore[]; top_gaps: TopGap[]; snapshot_id?: number | null }
   | { type: 'error'; error: string };
 
@@ -135,6 +136,7 @@ export default function Scorecard({
   setScorecard: (s: ScorecardType) => void;
 }) {
   const [phase, setPhase] = useState<'idle' | 'running' | 'done'>(scorecard ? 'done' : 'idle');
+  const [progressByKey, setProgressByKey] = useState<Record<string, string>>({});
   const [pillarsByKey, setPillarsByKey] = useState<Record<string, PillarScore>>(() =>
     scorecard ? Object.fromEntries(scorecard.pillars.map((p) => [p.key, p])) : {}
   );
@@ -189,6 +191,7 @@ export default function Scorecard({
     if (phase === 'running') return;
     setError(null);
     setPillarsByKey({});
+    setProgressByKey({});
     setOverall(null);
     setTopGaps([]);
     setCurrentId(null);
@@ -208,6 +211,8 @@ export default function Scorecard({
         if (ev.type === 'pillar') {
           collected[ev.pillar.key] = ev.pillar;
           setPillarsByKey({ ...collected });
+        } else if (ev.type === 'pillar_progress') {
+          setProgressByKey((prev) => ({ ...prev, [ev.key]: ev.detail }));
         } else if (ev.type === 'complete') {
           completed = true;
           setOverall(ev.overall);
@@ -497,12 +502,13 @@ export default function Scorecard({
         {config.pillars.map((cp) => {
           const p = pillarsByKey[cp.key];
           if (!p) {
+            const prog = progressByKey[cp.key];
             return (
               <div key={cp.key} className="card flex items-center gap-4 px-4 py-3 opacity-70">
                 <Loader2 size={16} className="animate-spin text-ink-300 shrink-0 w-12" />
                 <div className="flex-1 min-w-0">
                   <span className="font-semibold text-ink-500">{cp.name}</span>
-                  <p className="text-xs text-ink-400 mt-0.5 truncate">Checking…</p>
+                  <p className="text-xs text-ink-400 mt-0.5 truncate" title={prog || undefined}>{prog || 'Checking…'}</p>
                 </div>
               </div>
             );

--- a/app/server/assessment/probes.py
+++ b/app/server/assessment/probes.py
@@ -379,17 +379,20 @@ _COV_SELECT = ("SELECT COUNT(*) AS total, "
                "SUM(CASE WHEN comment IS NOT NULL AND comment <> '' THEN 1 ELSE 0 END) AS commented FROM ")
 
 
-def _columns_coverage_query(catalogs_batch: list[str], system_ok: bool) -> str:
-    """Column comment-coverage query scoped to a batch of catalogs.
+def _coverage_query(view: str, catalogs_batch: list[str], system_ok: bool) -> str:
+    """Comment-coverage query for an information_schema ``view`` (tables/columns)
+    scoped to a batch of catalogs.
 
     system_ok: filter the metastore-wide view by ``table_catalog IN (...)`` (prunes
-    to just these catalogs). Per-catalog: UNION each catalog's own columns view.
+    to just these catalogs). Per-catalog: UNION each catalog's own view. Scoping both
+    tables and columns to the same catalog list keeps the 50/50 comment score
+    measured over one consistent population.
     """
     if system_ok:
         in_list = ", ".join("'" + c.replace("'", "''") + "'" for c in catalogs_batch)
-        return (_COV_SELECT + "system.information_schema.columns "
+        return (_COV_SELECT + f"system.information_schema.{view} "
                 f"WHERE table_catalog IN ({in_list}) AND table_schema <> 'information_schema'")
-    union = " UNION ALL ".join(f"SELECT * FROM `{c}`.information_schema.columns" for c in catalogs_batch)
+    union = " UNION ALL ".join(f"SELECT * FROM `{c}`.information_schema.{view}" for c in catalogs_batch)
     return _COV_SELECT + f"({union}) AS _c WHERE table_schema <> 'information_schema'"
 
 
@@ -400,18 +403,20 @@ async def _column_coverage_chunked(catalogs: list[str], system_ok: bool) -> tupl
     batches = [catalogs[i:i + _METADATA_BATCH_SIZE] for i in range(0, len(catalogs), _METADATA_BATCH_SIZE)]
     total_cats = len(catalogs)
     sem = asyncio.Semaphore(_METADATA_SCAN_CONCURRENCY)
-    c_total = c_commented = scanned = 0
+    c_total = c_commented = scanned = ok_cats = failed_cats = 0
 
-    async def _one(batch: list[str]) -> tuple[int, int, int]:
+    async def _one(batch: list[str]) -> tuple[int, int, int, bool]:
         async with sem:
             try:
-                rows = await execute_sql(_columns_coverage_query(batch, system_ok))
-                return len(batch), int(rows[0].get("total") or 0), int(rows[0].get("commented") or 0)
+                rows = await execute_sql(_coverage_query("columns", batch, system_ok))
+                return len(batch), int(rows[0].get("total") or 0), int(rows[0].get("commented") or 0), True
             except Exception as e:
-                # A single bad batch shouldn't sink the whole scan — count it as
-                # scanned (so the watchdog sees progress) with zero coverage.
+                # An isolated bad batch (e.g. one unreadable catalog) shouldn't sink
+                # the whole scan — record it as failed (not as real 0% coverage). If
+                # EVERY batch fails (permissions lost, warehouse down) we raise below
+                # so the pillar degrades to "unavailable" rather than a fake 0%.
                 logger.warning(f"metadata column batch failed ({len(batch)} catalogs): {str(e)[:100]}")
-                return len(batch), 0, 0
+                return len(batch), 0, 0, False
 
     tasks = [asyncio.ensure_future(_one(b)) for b in batches]
     pending = set(tasks)
@@ -427,50 +432,74 @@ async def _column_coverage_chunked(catalogs: list[str], system_ok: bool) -> tupl
                     f"{_METADATA_NO_PROGRESS_TIMEOUT}s ({scanned}/{total_cats} catalogs scanned)"
                 )
             for d in done:
-                ncat, t, c = d.result()
+                ncat, t, c, ok = d.result()
                 scanned += ncat
-                c_total += t
-                c_commented += c
+                if ok:
+                    ok_cats += ncat
+                    c_total += t
+                    c_commented += c
+                else:
+                    failed_cats += ncat
                 _emit_progress("metadata", scanned, total_cats,
                                f"Scanned {scanned}/{total_cats} catalogs · {c_commented}/{c_total} columns commented")
     finally:
+        # Cancel any still-pending batches (timeout path) and await them so the
+        # cancellations settle — no orphaned tasks or unretrieved-exception warnings.
         for t in tasks:
             if not t.done():
                 t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Every batch failed → this is an access/infra failure, not real 0% coverage.
+    # Raise so probe_metadata marks the pillar unavailable (pre-chunking behavior).
+    if ok_cats == 0:
+        raise RuntimeError(f"column coverage scan failed for all {total_cats} catalogs")
+    if failed_cats:
+        logger.warning(f"metadata scan: {failed_cats}/{total_cats} catalogs unreadable; "
+                       f"coverage computed over the {ok_cats} readable")
     return c_total, c_commented
 
 
 async def probe_metadata() -> dict:
     s = await _resolve_sources()
     tbl = _src("tables", s)
-    col = _src("columns", s)
     if tbl is None:
         return _empty(_no_catalogs_note("metadata assessment"))
     try:
-        rows = await execute_sql(
-            f"""SELECT COUNT(*) AS total,
-                       SUM(CASE WHEN comment IS NOT NULL AND comment <> '' THEN 1 ELSE 0 END) AS commented
-                FROM {tbl} WHERE table_schema <> 'information_schema'"""
-        )
+        system_ok = bool(s.get("system_ok"))
+        catalogs = s.get("catalogs") or []
+
+        # Table comment coverage — one fast query. In system mode the metastore-wide
+        # tables view also spans internal catalogs (system/samples/…), but column
+        # coverage below is scoped to the enumerated non-internal catalogs; exclude
+        # the same internal catalogs here so both halves of the 50/50 score measure
+        # the same population. (Per-catalog _src is already scoped to that list.)
+        if system_ok:
+            internal_list = ", ".join("'" + c + "'" for c in _INTERNAL_CATALOGS)
+            tables_query = (_COV_SELECT + "system.information_schema.tables "
+                            "WHERE table_schema <> 'information_schema' "
+                            f"AND table_catalog NOT IN ({internal_list})")
+        else:
+            tables_query = _COV_SELECT + f"{tbl} WHERE table_schema <> 'information_schema'"
+        rows = await execute_sql(tables_query)
         t_total = int(rows[0].get("total") or 0)
         t_commented = int(rows[0].get("commented") or 0)
 
         # Heavy read — scan columns coverage in per-catalog batches so a wide
         # metastore fills in progressively instead of timing out on one big scan.
         # Fall back to a single query only when there's no catalog list to chunk by.
-        catalogs = s.get("catalogs") or []
         if catalogs:
-            c_total, c_commented = await _column_coverage_chunked(catalogs, bool(s.get("system_ok")))
-        elif col is not None:
-            crows = await execute_sql(
-                f"""SELECT COUNT(*) AS total,
-                           SUM(CASE WHEN comment IS NOT NULL AND comment <> '' THEN 1 ELSE 0 END) AS commented
-                    FROM {col} WHERE table_schema <> 'information_schema'"""
-            )
-            c_total = int(crows[0].get("total") or 0)
-            c_commented = int(crows[0].get("commented") or 0)
+            c_total, c_commented = await _column_coverage_chunked(catalogs, system_ok)
         else:
-            c_total = c_commented = 0
+            col = _src("columns", s)  # built lazily — only the no-catalog-list fallback needs it
+            if col is not None:
+                crows = await execute_sql(
+                    _COV_SELECT + f"{col} WHERE table_schema <> 'information_schema'"
+                )
+                c_total = int(crows[0].get("total") or 0)
+                c_commented = int(crows[0].get("commented") or 0)
+            else:
+                c_total = c_commented = 0
 
         tagged_tables = None
         tt = _src("table_tags", s)

--- a/app/server/assessment/probes.py
+++ b/app/server/assessment/probes.py
@@ -98,6 +98,30 @@ def _pct(num, den) -> float:
 
 
 # ---------------------------------------------------------------------------
+# Progress channel
+# ---------------------------------------------------------------------------
+# A probe can report intra-probe progress (e.g. the metadata scan working through
+# catalog batches) by pushing events onto a queue the streaming assessment drains.
+# run_assessment_stream primes this contextvar with a queue before dispatching
+# probes; contextvars are copied into each probe task, so a probe can find the sink
+# and emit without any change to its call signature. When no queue is primed
+# (non-streaming run_assessment, or unit tests) emitting is a no-op.
+_progress_sink: contextvars.ContextVar = contextvars.ContextVar("assessment_progress_sink", default=None)
+
+
+def _emit_progress(key: str, done: int, total: int, detail: str) -> None:
+    """Best-effort: push a pillar-progress event to the streaming sink if primed.
+    Never blocks and never raises into the probe (progress is advisory)."""
+    sink = _progress_sink.get()
+    if sink is None:
+        return
+    try:
+        sink.put_nowait({"type": "pillar_progress", "key": key, "done": done, "total": total, "detail": detail})
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Source resolution
 # ---------------------------------------------------------------------------
 # SP-only cache: used when no user token is present (scheduled/unattended mode).
@@ -338,6 +362,84 @@ async def probe_uc_foundation() -> dict:
 # ---------------------------------------------------------------------------
 # 2. Metadata richness (comments + tags)
 # ---------------------------------------------------------------------------
+# --- Metadata scan chunking -------------------------------------------------
+# Column comment coverage is the heaviest metadata read: information_schema.columns
+# has a row per column of every table. On a wide metastore (thousands of catalogs)
+# one metastore-wide scan runs for many minutes and times out. Instead we scan in
+# per-catalog batches with bounded concurrency, accumulating coverage and emitting
+# progress as batches land. Tuned against a 1068-catalog workspace (a 30-catalog
+# batch returns in ~7s): 25/batch × 6 concurrent finishes ~1068 catalogs in <1 min.
+_METADATA_BATCH_SIZE = 25
+_METADATA_SCAN_CONCURRENCY = 6
+# Stall only if NO batch completes within this window (not a fixed total deadline),
+# so a slow-but-progressing scan of a huge metastore is allowed to finish.
+_METADATA_NO_PROGRESS_TIMEOUT = 300  # seconds
+
+_COV_SELECT = ("SELECT COUNT(*) AS total, "
+               "SUM(CASE WHEN comment IS NOT NULL AND comment <> '' THEN 1 ELSE 0 END) AS commented FROM ")
+
+
+def _columns_coverage_query(catalogs_batch: list[str], system_ok: bool) -> str:
+    """Column comment-coverage query scoped to a batch of catalogs.
+
+    system_ok: filter the metastore-wide view by ``table_catalog IN (...)`` (prunes
+    to just these catalogs). Per-catalog: UNION each catalog's own columns view.
+    """
+    if system_ok:
+        in_list = ", ".join("'" + c.replace("'", "''") + "'" for c in catalogs_batch)
+        return (_COV_SELECT + "system.information_schema.columns "
+                f"WHERE table_catalog IN ({in_list}) AND table_schema <> 'information_schema'")
+    union = " UNION ALL ".join(f"SELECT * FROM `{c}`.information_schema.columns" for c in catalogs_batch)
+    return _COV_SELECT + f"({union}) AS _c WHERE table_schema <> 'information_schema'"
+
+
+async def _column_coverage_chunked(catalogs: list[str], system_ok: bool) -> tuple[int, int]:
+    """Total (columns, commented-columns) computed in per-catalog batches with
+    bounded concurrency. Emits pillar_progress as each batch lands and raises
+    TimeoutError only if no batch completes within _METADATA_NO_PROGRESS_TIMEOUT."""
+    batches = [catalogs[i:i + _METADATA_BATCH_SIZE] for i in range(0, len(catalogs), _METADATA_BATCH_SIZE)]
+    total_cats = len(catalogs)
+    sem = asyncio.Semaphore(_METADATA_SCAN_CONCURRENCY)
+    c_total = c_commented = scanned = 0
+
+    async def _one(batch: list[str]) -> tuple[int, int, int]:
+        async with sem:
+            try:
+                rows = await execute_sql(_columns_coverage_query(batch, system_ok))
+                return len(batch), int(rows[0].get("total") or 0), int(rows[0].get("commented") or 0)
+            except Exception as e:
+                # A single bad batch shouldn't sink the whole scan — count it as
+                # scanned (so the watchdog sees progress) with zero coverage.
+                logger.warning(f"metadata column batch failed ({len(batch)} catalogs): {str(e)[:100]}")
+                return len(batch), 0, 0
+
+    tasks = [asyncio.ensure_future(_one(b)) for b in batches]
+    pending = set(tasks)
+    _emit_progress("metadata", 0, total_cats, f"Scanning column metadata across {total_cats} catalogs…")
+    try:
+        while pending:
+            done, pending = await asyncio.wait(
+                pending, timeout=_METADATA_NO_PROGRESS_TIMEOUT, return_when=asyncio.FIRST_COMPLETED
+            )
+            if not done:
+                raise TimeoutError(
+                    f"metadata column scan stalled — no batch completed in "
+                    f"{_METADATA_NO_PROGRESS_TIMEOUT}s ({scanned}/{total_cats} catalogs scanned)"
+                )
+            for d in done:
+                ncat, t, c = d.result()
+                scanned += ncat
+                c_total += t
+                c_commented += c
+                _emit_progress("metadata", scanned, total_cats,
+                               f"Scanned {scanned}/{total_cats} catalogs · {c_commented}/{c_total} columns commented")
+    finally:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+    return c_total, c_commented
+
+
 async def probe_metadata() -> dict:
     s = await _resolve_sources()
     tbl = _src("tables", s)
@@ -353,13 +455,22 @@ async def probe_metadata() -> dict:
         t_total = int(rows[0].get("total") or 0)
         t_commented = int(rows[0].get("commented") or 0)
 
-        crows = await execute_sql(
-            f"""SELECT COUNT(*) AS total,
-                       SUM(CASE WHEN comment IS NOT NULL AND comment <> '' THEN 1 ELSE 0 END) AS commented
-                FROM {col} WHERE table_schema <> 'information_schema'"""
-        )
-        c_total = int(crows[0].get("total") or 0)
-        c_commented = int(crows[0].get("commented") or 0)
+        # Heavy read — scan columns coverage in per-catalog batches so a wide
+        # metastore fills in progressively instead of timing out on one big scan.
+        # Fall back to a single query only when there's no catalog list to chunk by.
+        catalogs = s.get("catalogs") or []
+        if catalogs:
+            c_total, c_commented = await _column_coverage_chunked(catalogs, bool(s.get("system_ok")))
+        elif col is not None:
+            crows = await execute_sql(
+                f"""SELECT COUNT(*) AS total,
+                           SUM(CASE WHEN comment IS NOT NULL AND comment <> '' THEN 1 ELSE 0 END) AS commented
+                    FROM {col} WHERE table_schema <> 'information_schema'"""
+            )
+            c_total = int(crows[0].get("total") or 0)
+            c_commented = int(crows[0].get("commented") or 0)
+        else:
+            c_total = c_commented = 0
 
         tagged_tables = None
         tt = _src("table_tags", s)

--- a/app/server/assessment/scoring.py
+++ b/app/server/assessment/scoring.py
@@ -15,7 +15,7 @@ from server.pillars import (
     level_from_score,
     readiness_stage,
 )
-from server.assessment.probes import PROBES, prime_request_sources
+from server.assessment.probes import PROBES, prime_request_sources, _progress_sink
 from server.sql_client import start_identity_capture, resolved_identity
 from server.content.library import best_practices_for, capability_summary
 
@@ -134,12 +134,37 @@ async def run_assessment_stream():
     by_key: dict[str, dict] = {}
     # Prime the shared per-request source resolution before dispatching probes.
     await prime_request_sources()
-    tasks = [asyncio.ensure_future(_run_probe(k)) for k in PROBES]
-    for fut in asyncio.as_completed(tasks):
-        key, probe = await fut
-        pillar = _assemble_pillar(PILLARS_BY_KEY[key], probe)
-        by_key[key] = pillar
-        yield {"type": "pillar", "pillar": pillar}
+
+    # A single queue carries both intra-probe progress (pillar_progress) and probe
+    # completions. Priming _progress_sink BEFORE creating the probe tasks means each
+    # task inherits it (contextvars are copied at task creation), so a probe can emit
+    # progress without a changed signature. We drain the queue until every probe has
+    # reported completion — interleaving progress events as they arrive.
+    q: asyncio.Queue = asyncio.Queue()
+    _progress_sink.set(q)
+
+    async def _runner(k: str) -> None:
+        key, probe = await _run_probe(k)
+        await q.put({"kind": "done", "key": key, "probe": probe})
+
+    tasks = [asyncio.ensure_future(_runner(k)) for k in PROBES]
+    remaining = len(tasks)
+    try:
+        while remaining > 0:
+            item = await q.get()
+            if item.get("kind") == "done":
+                key = item["key"]
+                pillar = _assemble_pillar(PILLARS_BY_KEY[key], item["probe"])
+                by_key[key] = pillar
+                remaining -= 1
+                yield {"type": "pillar", "pillar": pillar}
+            else:
+                # Already SSE-shaped progress event ({"type":"pillar_progress",...}).
+                yield item
+    finally:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
 
     ordered = [by_key[p["key"]] for p in PILLARS if p["key"] in by_key]
     yield {"type": "complete", "pillars": ordered, **_finalize(ordered)}


### PR DESCRIPTION
## Problem

Running an assessment on a workspace with a very large metastore (this surfaced on an FE sandbox with **1,068 catalogs / ~395k columns**) produced a **browser "network error"** and the **Metadata Richness pillar hung on "Checking…" forever.**

Root cause: `probe_metadata` ran a single metastore-wide aggregation over `system.information_schema.columns`. That scan fans out across every catalog with no pruning — it ran **>5.5 min** (measured, cancelled) on 1,068 catalogs. `execute_sql` caps at 50s wait + 120s poll, but the Databricks Apps SSE proxy drops the streaming connection first (no bytes for the pillar for over a minute) → "network error", and the pillar's completion event never arrives. The other 6 pillars query `tables`/constraints (70k rows, ~2s) so they finished fine — matching the observed pattern.

## Fix — chunk + parallelize + progress + no-progress watchdog

- **Chunk** column-comment coverage into **per-catalog batches**. In system mode, filter the metastore-wide view by `table_catalog IN (...)`, which **prunes** (measured: 1 catalog ~3s, 30 catalogs ~7s vs. the full scan hanging); in per-catalog mode, batch the UNIONs.
- **Parallelize** with bounded concurrency (25/batch × 6 concurrent).
- **Progress**: `run_assessment_stream` plumbs an `asyncio.Queue` via a contextvar so a probe can emit `pillar_progress` events without a signature change. The frontend renders a live **"Scanned N/M catalogs · X/Y columns commented"** status on the still-checking pillar.
- **No-progress watchdog**: `asyncio.wait(..., FIRST_COMPLETED, timeout=300)` per wave — the scan stalls/errors only if **no batch completes within 5 minutes**, never on a fixed total deadline, so a slow-but-progressing scan of a huge metastore is allowed to finish. A single failed batch is tolerated (counts as progress, zero coverage) so one bad catalog can't sink the scan.

## Testing

- **Offline unit tests** (11/11): correct summing across batches, `table_catalog IN` pruning query shape, per-catalog UNION shape, progress-event emission (initial + per-batch, `key=metadata`), single-bad-batch resilience, and the watchdog raising `TimeoutError` on a stall.
- **Frontend** builds clean (type-check passes).
- **Live end-to-end** on the 1,068-catalog workspace: metadata filled progressively (0 → 200 → 1040 → done), the assessment **completed** (overall 78/100; Metadata Richness now scores instead of hanging), **no browser network error**, no console errors, and app logs show **0 batch failures / 0 timeouts**.

Tuning constants (`_METADATA_BATCH_SIZE`, `_METADATA_SCAN_CONCURRENCY`, `_METADATA_NO_PROGRESS_TIMEOUT`) are grouped at the top of the metadata section in `probes.py`.

This pull request and its description were written by Isaac.