### PR TITLE
docs: clarify stable (release) vs staging (main) install in Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ guides, and the public Databricks accelerators that raise each pillar's score.
 
 ## Quick start
 
+**Get the code.** For a **stable build**, clone the latest tagged
+[release](https://github.com/databricks-solutions/genie-ontology-readiness/releases)
+— this is the recommended source for customer deployments. For a **staging build**
+with the newest, unreleased changes, clone `main` directly.
+
+```bash
+# Stable — latest release (recommended)
+tag=$(gh release view --repo databricks-solutions/genie-ontology-readiness --json tagName -q .tagName)
+git clone --branch "$tag" https://github.com/databricks-solutions/genie-ontology-readiness.git
+# (no gh? browse the Releases page above and: git clone --branch <tag> <repo-url>)
+
+# Staging — latest main (newest, unreleased)
+git clone https://github.com/databricks-solutions/genie-ontology-readiness.git
+```
+
+Then build and deploy:
+
 ```bash
 cd app/frontend && npm install && npm run build && cd ../..
 databricks bundle deploy -t dev --profile <p> --var="warehouse_id=<id>"


### PR DESCRIPTION
## What

Adds a **Get the code** step to the Quick start in `README.md` that distinguishes how to obtain the source:

- **Stable build** — clone the latest tagged [release](https://github.com/databricks-solutions/genie-ontology-readiness/releases). Recommended for customer deployments.
- **Staging build** — clone `main` directly for the newest, unreleased changes.

The existing build/deploy commands are unchanged, just relabeled as the follow-on "Then build and deploy" step.

## Why

Quick start previously assumed you already had the repo but never said how to get it, and gave no guidance on release vs `main`. Now that tagged releases exist (`v1.1.0`), customer deployments should pull a stable tag rather than tracking `main`.

## Scope

Docs only — `README.md`. No code or behavior changes.

This pull request and its description were written by Isaac.